### PR TITLE
add protocol scheme validation

### DIFF
--- a/codec.go
+++ b/codec.go
@@ -51,7 +51,7 @@ func Parse(s string) (*LNURL, error) {
 	if err != nil {
 		return nil, err
 	}
-	psuf, icann := publicsuffix.PublicSuffix(dom)
+	psuf, icann := publicsuffix.PublicSuffix(tld)
 	return &LNURL{
 		Subdomain:    sub,
 		Domain:       domName,

--- a/codec_test.go
+++ b/codec_test.go
@@ -109,7 +109,7 @@ func TestLNURLEncodeStrict(t *testing.T) {
 			args: args{actualurl: "lnurl"},
 			want: strings.ToUpper("lnurl1d3h82unvjhypn2"), wantErr: true},
 		{desc: "invalid",
-			args: args{actualurl: "lnurl.msfmsdkfns&dfandfasdf"},                                              // invalid TLD
+			args: args{actualurl: "lnurl.msfmsdkfns&dfandfasdf"},                                              // invalid tld
 			want: strings.ToUpper("LNURL1D3H82UNV9EKHXENDWDJXKENWWVNXGENPDEJXVCTNV3NQXM32ED"), wantErr: true}, // lnurl.msfmsdkfns&dfandfasdf
 		{desc: "invalid_domain_name",
 			args: args{actualurl: "lnur%%%l"},
@@ -184,7 +184,7 @@ func TestLNURLEncode(t *testing.T) {
 			args: args{actualurl: "lnurl"},
 			want: strings.ToUpper("lnurl1d3h82unvjhypn2"), wantErr: false},
 		{desc: "invalid",
-			args: args{actualurl: "lnurl.msfmsdkfns&dfandfasdf"},                                               // invalid TLD
+			args: args{actualurl: "lnurl.msfmsdkfns&dfandfasdf"},                                               // invalid tld
 			want: strings.ToUpper("LNURL1D3H82UNV9EKHXENDWDJXKENWWVNXGENPDEJXVCTNV3NQXM32ED"), wantErr: false}, // lnurl.msfmsdkfns&dfandfasdf
 		{desc: "invalid_domain_name",
 			args: args{actualurl: "lnur%%%l"},

--- a/codec_test.go
+++ b/codec_test.go
@@ -1,0 +1,218 @@
+package lnurl
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestLNURLDecode will test if LNURLDecode returns the expected string
+func TestLNURLDecode(t *testing.T) {
+	type args struct {
+		code string
+	}
+	tests := []struct {
+		name    string
+		desc    string
+		args    args
+		want    string
+		wantErr bool
+	}{
+		{desc: "simple",
+			args: args{code: "lnurl1d3h82unvwqaz7tmpwp5juenfv96x5ctx9e3k7mf0wccj7mrww4exctmsv9usxr8j98"},
+			want: "https://api.fiatjaf.com/v1/lnurl/pay"},
+		{desc: "puny",
+			args: args{code: "lnurl1dp68gurn8ghj77rw95khx7r3wc6kwv3nv3uhyvmpxserscfwvdhk6tmkxyhkcmn4wfkz7urp0y6jmn9j"},
+			want: "https://xn--sxqv5g23dyr3a428a.com/v1/lnurl/pay"}, // check puny code
+		{desc: "puny2",
+			args: args{code: "lnurl1dp68gurn8ghjle443052l909sxr7t8ulukgg6tnrdakj7a339akxuatjdshhqctea4v3jm"},
+			want: "https://测试假域名.com/v1/lnurl/pay"}, // check puny code
+		{desc: "puny_onion",
+			args: args{code: "lnurl1dp68gup69uh7ddvtazhetevpsljel8l9jzxjummwd9hkutmkxyhkcmn4wfkz7urp0ygc52rr"},
+			want: "http://测试假域名.onion/v1/lnurl/pay"}, // check puny onion (not sure know if this is possible)
+		{desc: "string",
+			args: args{code: "lnurl1d3h82unvjhypn2"},
+			want: "lnurl", wantErr: true}, // invalid domain name. returns error and decoded input
+		{desc: "string_uppercase",
+			args: args{code: strings.ToUpper("lnurl1d3h82unvjhypn2")},
+			want: "lnurl", wantErr: true},
+		{desc: "httpsScheme",
+			args: args{code: "https://lnurl.fiatjaf.com"}, // do noting
+			want: "https://lnurl.fiatjaf.com"},
+		{desc: "lnurlp",
+			args: args{code: "lnurlp://lnurl.fiatjaf.com"}, // change scheme
+			want: "https://lnurl.fiatjaf.com"},
+		{desc: "onion",
+			args: args{code: "onion://lnurl.fiatjaf.onion"}, // change scheme
+			want: "http://lnurl.fiatjaf.onion"},
+		{desc: "encoded_onion",
+			args: args{code: "lnurl1dahxjmmw8ghj7mrww4exctnxd9shg6npvchx7mnfdahquxueex"}, // change scheme
+			want: "http://lnurl.fiatjaf.onion"},
+		{desc: "encoded_https_onion",
+			args: args{code: "lnurl1dp68gurn8ghj7mrww4exctnxd9shg6npvchx7mnfdahq874q6e"}, // change scheme
+			want: "http://lnurl.fiatjaf.onion"},
+	}
+	for _, tt := range tests {
+		tt.name = tt.args.code
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := LNURLDecode(tt.args.code)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("LNURLDecode() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("LNURLDecode() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestLNURLEncodeWithValidation(t *testing.T) {
+	type args struct {
+		actualurl string
+	}
+	tests := []struct {
+		name    string
+		desc    string
+		args    args
+		want    string
+		wantErr bool
+	}{
+		{desc: "com.org_invalid",
+			args: args{actualurl: "lnurl.com.orgs"},                                      //invalid tld
+			want: strings.ToUpper("LNURL1D3H82UNV9E3K7MFWDAEXWUCYVANJJ"), wantErr: true}, // lnurl.com.orgs
+		{desc: "onion",
+			args: args{actualurl: "http://juhaavcaxhxlp77nkq76byazcldy2hlmovfu2epvl5ankdibsot4csyd.onion/"},                                                                        //invalid tld
+			want: strings.ToUpper("lnurl1dp68gup69uhk5atgv9shvcmp0p58smrsxumku6m3xumxy7tp0f3kcerexf5xcmt0wen82vn9wpmxcdtpde4kg6tzwdhhgdrrwdukgtn0de5k7m30p4k848"), wantErr: false}, // lnurl.com.orgs
+		{desc: "invalid",
+			args: args{actualurl: "lnurl.msfmsdkfns&dfandfasdf"},                                              // invalid TLD
+			want: strings.ToUpper("LNURL1D3H82UNV9EKHXENDWDJXKENWWVNXGENPDEJXVCTNV3NQXM32ED"), wantErr: true}, // lnurl.msfmsdkfns&dfandfasdf
+		{desc: "com.org",
+			args: args{actualurl: "lnurl.com.org"},
+			want: strings.ToUpper("LNURL1DP68GURN8GHJ7MRWW4EXCTNRDAKJUMMJVUK5QJ46"), wantErr: false}, // https://lnurl.com.org,
+		{desc: "invalid_domain_name",
+			args: args{actualurl: "lnurl"},
+			want: strings.ToUpper("lnurl1d3h82unvjhypn2"), wantErr: true},
+		{desc: "invalid_domain_name",
+			args: args{actualurl: "lnur%%%l"},
+			want: strings.ToUpper("lnurl1d3h82u39y5jkc45g4zl"), wantErr: true},
+		{desc: "com",
+			args: args{actualurl: "lnurl.com"},
+			want: "LNURL1DP68GURN8GHJ7MRWW4EXCTNRDAKS6NPC70", wantErr: false}, // https://lnurl.com
+	}
+	for _, tt := range tests {
+		tt.name = tt.args.actualurl
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := LNURLEncodeWithValidation(tt.args.actualurl)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("LNURLDecode() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("LNURLDecode() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestLNURLDecode will test if LNURLDecode returns the expected string
+func TestLNURLEncode(t *testing.T) {
+	type args struct {
+		actualurl string
+	}
+	tests := []struct {
+		name    string
+		desc    string
+		args    args
+		want    string
+		wantErr bool
+	}{
+		{desc: "com.org",
+			args: args{actualurl: "lnurl.com.org"},
+			want: strings.ToUpper("LNURL1DP68GURN8GHJ7MRWW4EXCTNRDAKJUMMJVUK5QJ46"), wantErr: false}, // https://lnurl.com.org,
+		{desc: "invalid_domain_name",
+			args: args{actualurl: "lnurl"},
+			want: strings.ToUpper("lnurl1d3h82unvjhypn2"), wantErr: false}, // no domain validation
+		{desc: "invalid_domain_name",
+			args: args{actualurl: "lnur%%%l"},
+			want: strings.ToUpper("lnurl1d3h82u39y5jkc45g4zl"), wantErr: false}, // no domain validation
+		{desc: "com",
+			args: args{actualurl: "lnurl.com"},
+			want: "LNURL1DP68GURN8GHJ7MRWW4EXCTNRDAKS6NPC70", wantErr: false}, // https://lnurl.com
+		{desc: "lnurlp",
+			args: args{actualurl: "lnurlp://api.fiatjaf.com/v2/lnurl/pay"},
+			want: "LNURL1DP68GURN8GHJ7CTSDYHXV6TPW34XZE3WVDHK6TMKXGHKCMN4WFKZ7URP0Y0Q3PEG"}, // https://api.fiatjaf.com/v2/lnurl/pay
+		{desc: "onion_lnurlp",
+			args: args{actualurl: "lnurlp://api.fiatjaf.onion/v2/lnurl/pay"},
+			want: "LNURL1DP68GUP69UHKZURF9ENXJCT5DFSKVTN0DE5K7M30WCEZ7MRWW4EXCTMSV9USWEVHQG"}, // http://api.fiatjaf.onion/v2/lnurl/pay
+		{desc: "https_onion",
+			args: args{actualurl: "https://api.fiatjaf.onion/v2/lnurl/pay"},
+			want: "LNURL1DP68GUP69UHKZURF9ENXJCT5DFSKVTN0DE5K7M30WCEZ7MRWW4EXCTMSV9USWEVHQG"}, // http://api.fiatjaf.onion/v2/lnurl/pay
+		{desc: "http",
+			args: args{actualurl: "http://api.fiatjaf.com/v2/lnurl/pay"},
+			want: "LNURL1DP68GURN8GHJ7CTSDYHXV6TPW34XZE3WVDHK6TMKXGHKCMN4WFKZ7URP0Y0Q3PEG"}, // https://api.fiatjaf.com/v2/lnurl/pay
+	}
+	for _, tt := range tests {
+		tt.name = tt.args.actualurl
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := LNURLEncode(tt.args.actualurl)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("LNURLDecode() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("LNURLDecode() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestLNURLEncodeDecode will test if encoding and decoding a lnurl will result in the same string
+func TestLNURLEncodeDecode(t *testing.T) {
+	type args struct {
+		input string
+	}
+	tests := []struct {
+		desc    string
+		name    string
+		args    args
+		wantErr bool
+		want    string
+	}{
+		{desc: "no_scheme_onion",
+			args: args{input: "hellosir.onion"}, wantErr: true, want: "http://hellosir.onion"}, // will be encoded to http://
+		{desc: "https",
+			args: args{input: "https://api.fiatjaf.com/v1/lnurl/pay"}, want: "https://api.fiatjaf.com/v1/lnurl/pay"},
+		{desc: "https_scheme",
+			args: args{input: "https://lnurl.fiatjaf.com"}, want: "https://lnurl.fiatjaf.com"},
+		{desc: "lnurlp",
+			args: args{input: "lnurlp://lnurl.fiatjaf.com"}, want: "https://lnurl.fiatjaf.com"}, // will be encoded to https://
+		{desc: "no_scheme_com",
+			args: args{input: "lnurl.fiatjaf.com"}, want: "https://lnurl.fiatjaf.com"},
+		{desc: "no_domain_string",
+			args: args{input: "lnurl"}, want: "lnurl", wantErr: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// encode string first
+			enc, err := LNURLEncode(tt.args.input)
+			if err != nil {
+				if !tt.wantErr {
+					t.Errorf("LNURLDecode() error = %v, wantErr %v", err, tt.wantErr)
+				}
+				return
+			}
+			// decode string
+			dec, err := LNURLDecode(enc)
+			if err != nil {
+				if !tt.wantErr {
+					t.Errorf("LNURLDecode() error = %v, wantErr %v", err, tt.wantErr)
+				}
+				return
+			}
+			// check if decoded string == actualurl
+			if dec != tt.want {
+				t.Errorf("LNURLDecode() enc = %v, dec %v", enc, dec)
+			}
+		})
+	}
+}

--- a/codec_test.go
+++ b/codec_test.go
@@ -17,18 +17,21 @@ func TestLNURLDecode(t *testing.T) {
 		want    string
 		wantErr bool
 	}{
-		{desc: "simple",
-			args: args{code: "lnurl1d3h82unvwqaz7tmpwp5juenfv96x5ctx9e3k7mf0wccj7mrww4exctmsv9usxr8j98"},
+		{desc: "change_scheme",
+			args: args{code: "lnurl1d3h82unvwqaz7tmpwp5juenfv96x5ctx9e3k7mf0wccj7mrww4exctmsv9usxr8j98"}, // lnurlp://api.fiatjaf.com/v1/lnurl/pay
 			want: "https://api.fiatjaf.com/v1/lnurl/pay"},
 		{desc: "puny",
-			args: args{code: "lnurl1dp68gurn8ghj77rw95khx7r3wc6kwv3nv3uhyvmpxserscfwvdhk6tmkxyhkcmn4wfkz7urp0y6jmn9j"},
-			want: "https://xn--sxqv5g23dyr3a428a.com/v1/lnurl/pay"}, // check puny code
+			args: args{code: "lnurl1dp68gurn8ghj77rw95khx7r3wc6kwv3nv3uhyvmpxserscfwvdhk6tmkxyhkcmn4wfkz7urp0y6jmn9j"}, // https://xn--sxqv5g23dyr3a428a.com/v1/lnurl/pay
+			want: "https://xn--sxqv5g23dyr3a428a.com/v1/lnurl/pay"},                                                    // check puny code
 		{desc: "puny2",
 			args: args{code: "lnurl1dp68gurn8ghjle443052l909sxr7t8ulukgg6tnrdakj7a339akxuatjdshhqctea4v3jm"},
 			want: "https://测试假域名.com/v1/lnurl/pay"}, // check puny code
 		{desc: "puny_onion",
 			args: args{code: "lnurl1dp68gup69uh7ddvtazhetevpsljel8l9jzxjummwd9hkutmkxyhkcmn4wfkz7urp0ygc52rr"},
 			want: "http://测试假域名.onion/v1/lnurl/pay"}, // check puny onion (not sure know if this is possible)
+		{desc: "puny_onion",
+			args: args{code: "lnurl1dp68gurn8ghj7er0d4skjm3wdahxjmmw9amrztmvde6hymp0wpshjcw5kvw"},
+			want: "http://domain.onion/v1/lnurl/pay"}, // check puny onion (not sure know if this is possible)
 		{desc: "string",
 			args: args{code: "lnurl1d3h82unvjhypn2"},
 			want: "lnurl", wantErr: true}, // invalid domain name. returns error and decoded input
@@ -203,6 +206,29 @@ func TestLNURLEncodeDecode(t *testing.T) {
 			}
 			// decode string
 			dec, err := LNURLDecode(enc)
+			if err != nil {
+				if !tt.wantErr {
+					t.Errorf("LNURLDecode() error = %v, wantErr %v", err, tt.wantErr)
+				}
+				return
+			}
+			// decode string
+			dec, err = LNURLDecode(enc)
+			if err != nil {
+				if !tt.wantErr {
+					t.Errorf("LNURLDecode() error = %v, wantErr %v", err, tt.wantErr)
+				}
+				return
+			}
+			enc, err = LNURLEncode(tt.args.input)
+			if err != nil {
+				if !tt.wantErr {
+					t.Errorf("LNURLDecode() error = %v, wantErr %v", err, tt.wantErr)
+				}
+				return
+			}
+			// decode string
+			dec, err = LNURLDecode(enc)
 			if err != nil {
 				if !tt.wantErr {
 					t.Errorf("LNURLDecode() error = %v, wantErr %v", err, tt.wantErr)

--- a/codec_test.go
+++ b/codec_test.go
@@ -1,12 +1,15 @@
 package lnurl
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 )
 
-// TestLNURLDecode will test if LNURLDecode returns the expected string
-func TestLNURLDecode(t *testing.T) {
+// Starting tests with validation
+
+// TestLNURLDecodeStrict will test if LNURLDecodeStrict returns the expected string
+func TestLNURLDecodeStrict(t *testing.T) {
 	type args struct {
 		code string
 	}
@@ -27,8 +30,8 @@ func TestLNURLDecode(t *testing.T) {
 			args: args{code: "lnurl1dp68gurn8ghjle443052l909sxr7t8ulukgg6tnrdakj7a339akxuatjdshhqctea4v3jm"},
 			want: "https://测试假域名.com/v1/lnurl/pay"}, // check puny code
 		{desc: "puny_onion",
-			args: args{code: "lnurl1dp68gup69uh7ddvtazhetevpsljel8l9jzxjummwd9hkutmkxyhkcmn4wfkz7urp0ygc52rr"},
-			want: "http://测试假域名.onion/v1/lnurl/pay"}, // check puny onion (not sure know if this is possible)
+			args: args{code: "lnurl1dp68gup69uh7ddvtazhetevpsljel8l9jzxjummwd9hkutmkxyhkcmn4wfkz7urp0ygc52rr"}, // http://测试假域名.onion/v1/lnurl/pay
+			want: "http://测试假域名.onion/v1/lnurl/pay"},                                                           // check puny onion (not sure know if this is possible)
 		{desc: "puny_onion",
 			args: args{code: "lnurl1dp68gurn8ghj7er0d4skjm3wdahxjmmw9amrztmvde6hymp0wpshjcw5kvw"},
 			want: "http://domain.onion/v1/lnurl/pay"}, // check puny onion (not sure know if this is possible)
@@ -56,20 +59,21 @@ func TestLNURLDecode(t *testing.T) {
 	}
 	for _, tt := range tests {
 		tt.name = tt.args.code
-		t.Run(tt.name, func(t *testing.T) {
-			got, err := LNURLDecode(tt.args.code)
+		t.Run(fmt.Sprintf("%s__%s", tt.name, tt.desc), func(t *testing.T) {
+			got, err := LNURLDecodeStrict(tt.args.code)
 			if (err != nil) != tt.wantErr {
-				t.Errorf("LNURLDecode() error = %v, wantErr %v", err, tt.wantErr)
+				t.Errorf("LNURLDecodeStrict() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
 			if got != tt.want {
-				t.Errorf("LNURLDecode() got = %v, want %v", got, tt.want)
+				t.Errorf("LNURLDecodeStrict() got = %v, want %v", got, tt.want)
 			}
 		})
 	}
 }
 
-func TestLNURLEncodeWithValidation(t *testing.T) {
+// TestLNURLEncodeStrict will test if LNURLEncodeStrict returns the expected string
+func TestLNURLEncodeStrict(t *testing.T) {
 	type args struct {
 		actualurl string
 	}
@@ -80,64 +84,36 @@ func TestLNURLEncodeWithValidation(t *testing.T) {
 		want    string
 		wantErr bool
 	}{
-		{desc: "com.org_invalid",
+		{desc: "invalid_tld_want_error",
 			args: args{actualurl: "lnurl.com.orgs"},                                      //invalid tld
 			want: strings.ToUpper("LNURL1D3H82UNV9E3K7MFWDAEXWUCYVANJJ"), wantErr: true}, // lnurl.com.orgs
-		{desc: "onion",
-			args: args{actualurl: "http://juhaavcaxhxlp77nkq76byazcldy2hlmovfu2epvl5ankdibsot4csyd.onion/"},                                                                        //invalid tld
-			want: strings.ToUpper("lnurl1dp68gup69uhk5atgv9shvcmp0p58smrsxumku6m3xumxy7tp0f3kcerexf5xcmt0wen82vn9wpmxcdtpde4kg6tzwdhhgdrrwdukgtn0de5k7m30p4k848"), wantErr: false}, // lnurl.com.orgs
-		{desc: "invalid",
-			args: args{actualurl: "lnurl.msfmsdkfns&dfandfasdf"},                                              // invalid TLD
-			want: strings.ToUpper("LNURL1D3H82UNV9EKHXENDWDJXKENWWVNXGENPDEJXVCTNV3NQXM32ED"), wantErr: true}, // lnurl.msfmsdkfns&dfandfasdf
-		{desc: "com.org",
-			args: args{actualurl: "lnurl.com.org"},
-			want: strings.ToUpper("LNURL1DP68GURN8GHJ7MRWW4EXCTNRDAKJUMMJVUK5QJ46"), wantErr: false}, // https://lnurl.com.org,
 		{desc: "invalid_domain_name",
 			args: args{actualurl: "lnurl"},
 			want: strings.ToUpper("lnurl1d3h82unvjhypn2"), wantErr: true},
+		{desc: "invalid",
+			args: args{actualurl: "lnurl.msfmsdkfns&dfandfasdf"},                                              // invalid TLD
+			want: strings.ToUpper("LNURL1D3H82UNV9EKHXENDWDJXKENWWVNXGENPDEJXVCTNV3NQXM32ED"), wantErr: true}, // lnurl.msfmsdkfns&dfandfasdf
 		{desc: "invalid_domain_name",
 			args: args{actualurl: "lnur%%%l"},
 			want: strings.ToUpper("lnurl1d3h82u39y5jkc45g4zl"), wantErr: true},
-		{desc: "com",
-			args: args{actualurl: "lnurl.com"},
-			want: "LNURL1DP68GURN8GHJ7MRWW4EXCTNRDAKS6NPC70", wantErr: false}, // https://lnurl.com
-	}
-	for _, tt := range tests {
-		tt.name = tt.args.actualurl
-		t.Run(tt.name, func(t *testing.T) {
-			got, err := LNURLEncodeWithValidation(tt.args.actualurl)
-			if (err != nil) != tt.wantErr {
-				t.Errorf("LNURLDecode() error = %v, wantErr %v", err, tt.wantErr)
-				return
-			}
-			if got != tt.want {
-				t.Errorf("LNURLDecode() got = %v, want %v", got, tt.want)
-			}
-		})
-	}
-}
-
-// TestLNURLDecode will test if LNURLDecode returns the expected string
-func TestLNURLEncode(t *testing.T) {
-	type args struct {
-		actualurl string
-	}
-	tests := []struct {
-		name    string
-		desc    string
-		args    args
-		want    string
-		wantErr bool
-	}{
+		{desc: "invalid_domain_name",
+			args: args{actualurl: "lnurl"},
+			want: strings.ToUpper("lnurl1d3h82unvjhypn2"), wantErr: true}, // no domain validation
+		{desc: "invalid_domain_name",
+			args: args{actualurl: "lnur%%%l"},
+			want: strings.ToUpper("lnurl1d3h82u39y5jkc45g4zl"), wantErr: true}, // no domain validation
+		{desc: "onion",
+			args: args{actualurl: "http://juhaavcaxhxlp77nkq76byazcldy2hlmovfu2epvl5ankdibsot4csyd.onion/"},
+			want: strings.ToUpper("lnurl1dp68gup69uhk5atgv9shvcmp0p58smrsxumku6m3xumxy7tp0f3kcerexf5xcmt0wen82vn9wpmxcdtpde4kg6tzwdhhgdrrwdukgtn0de5k7m30p4k848"), wantErr: false},
 		{desc: "com.org",
 			args: args{actualurl: "lnurl.com.org"},
 			want: strings.ToUpper("LNURL1DP68GURN8GHJ7MRWW4EXCTNRDAKJUMMJVUK5QJ46"), wantErr: false}, // https://lnurl.com.org,
-		{desc: "invalid_domain_name",
-			args: args{actualurl: "lnurl"},
-			want: strings.ToUpper("lnurl1d3h82unvjhypn2"), wantErr: false}, // no domain validation
-		{desc: "invalid_domain_name",
-			args: args{actualurl: "lnur%%%l"},
-			want: strings.ToUpper("lnurl1d3h82u39y5jkc45g4zl"), wantErr: false}, // no domain validation
+		{desc: "com",
+			args: args{actualurl: "lnurl.com"},
+			want: "LNURL1DP68GURN8GHJ7MRWW4EXCTNRDAKS6NPC70", wantErr: false}, // https://lnurl.com
+		{desc: "com.org",
+			args: args{actualurl: "lnurl.com.org"},
+			want: strings.ToUpper("LNURL1DP68GURN8GHJ7MRWW4EXCTNRDAKJUMMJVUK5QJ46"), wantErr: false}, // https://lnurl.com.org,
 		{desc: "com",
 			args: args{actualurl: "lnurl.com"},
 			want: "LNURL1DP68GURN8GHJ7MRWW4EXCTNRDAKS6NPC70", wantErr: false}, // https://lnurl.com
@@ -156,8 +132,142 @@ func TestLNURLEncode(t *testing.T) {
 	}
 	for _, tt := range tests {
 		tt.name = tt.args.actualurl
-		t.Run(tt.name, func(t *testing.T) {
+		t.Run(fmt.Sprintf("%s__%s", tt.name, tt.desc), func(t *testing.T) {
+			got, err := LNURLEncodeStrict(tt.args.actualurl)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("LNURLDecodeStrict() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("LNURLDecodeStrict() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+// Start test without validation
+
+// TestLNURLDecodeStrict will test if LNURLDecodeStrict returns the expected string
+func TestLNURLEncode(t *testing.T) {
+	type args struct {
+		actualurl string
+	}
+	tests := []struct {
+		name    string
+		desc    string
+		args    args
+		want    string
+		wantErr bool
+	}{
+		{desc: "invalid_tld_want_error",
+			args: args{actualurl: "lnurl.com.orgs"},                                       //invalid tld
+			want: strings.ToUpper("LNURL1D3H82UNV9E3K7MFWDAEXWUCYVANJJ"), wantErr: false}, // lnurl.com.orgs
+		{desc: "invalid_domain_name",
+			args: args{actualurl: "lnurl"},
+			want: strings.ToUpper("lnurl1d3h82unvjhypn2"), wantErr: false},
+		{desc: "invalid",
+			args: args{actualurl: "lnurl.msfmsdkfns&dfandfasdf"},                                               // invalid TLD
+			want: strings.ToUpper("LNURL1D3H82UNV9EKHXENDWDJXKENWWVNXGENPDEJXVCTNV3NQXM32ED"), wantErr: false}, // lnurl.msfmsdkfns&dfandfasdf
+		{desc: "invalid_domain_name",
+			args: args{actualurl: "lnur%%%l"},
+			want: strings.ToUpper("lnurl1d3h82u39y5jkc45g4zl"), wantErr: false},
+		{desc: "invalid_domain_name",
+			args: args{actualurl: "lnurl"},
+			want: strings.ToUpper("lnurl1d3h82unvjhypn2"), wantErr: false}, // no domain validation
+		{desc: "invalid_domain_name",
+			args: args{actualurl: "lnur%%%l"},
+			want: strings.ToUpper("lnurl1d3h82u39y5jkc45g4zl"), wantErr: false}, // no domain validation
+		{desc: "onion",
+			args: args{actualurl: "http://juhaavcaxhxlp77nkq76byazcldy2hlmovfu2epvl5ankdibsot4csyd.onion/"},
+			want: strings.ToUpper("lnurl1dp68gup69uhk5atgv9shvcmp0p58smrsxumku6m3xumxy7tp0f3kcerexf5xcmt0wen82vn9wpmxcdtpde4kg6tzwdhhgdrrwdukgtn0de5k7m30p4k848"), wantErr: false}, // http://juhaavcaxhxlp77nkq76byazcldy2hlmovfu2epvl5ankdibsot4csyd.onion/
+		{desc: "domain",
+			args: args{actualurl: "lnurl.com.org"},
+			want: strings.ToUpper("LNURL1D3H82UNV9E3K7MFWDAEXWSE0TLM"), wantErr: false}, // lnurl.com.org,
+		{desc: "domain",
+			args: args{actualurl: "lnurl.com"},
+			want: "LNURL1D3H82UNV9E3K7MG347503", wantErr: false}, // lnurl.com
+		{desc: "lnurlp",
+			args: args{actualurl: "lnurlp://api.fiatjaf.com/v2/lnurl/pay"},
+			want: "LNURL1D3H82UNVWQAZ7TMPWP5JUENFV96X5CTX9E3K7MF0WCEZ7MRWW4EXCTMSV9US75V5UG"}, // lnurlp://api.fiatjaf.com/v2/lnurl/pay
+		{desc: "onion_lnurlp",
+			args: args{actualurl: "lnurlp://api.fiatjaf.onion/v2/lnurl/pay"},
+			want: "LNURL1D3H82UNVWQAZ7TMPWP5JUENFV96X5CTX9EHKU6T0DCHHVV30D3H82UNV9ACXZ7GLKMARH"}, // lnurlp://api.fiatjaf.onion/v2/lnurl/pay
+		{desc: "https_onion",
+			args: args{actualurl: "https://api.fiatjaf.onion/v2/lnurl/pay"},
+			want: "LNURL1DP68GURN8GHJ7CTSDYHXV6TPW34XZE3WDAHXJMMW9AMRYTMVDE6HYMP0WPSHJMP4SG6"}, // https://api.fiatjaf.onion/v2/lnurl/pay
+		{desc: "http",
+			args: args{actualurl: "http://api.fiatjaf.com/v2/lnurl/pay"},
+			want: "LNURL1DP68GUP69UHKZURF9ENXJCT5DFSKVTNRDAKJ7A3J9AKXUATJDSHHQCTE6UJWJL"}, // http://api.fiatjaf.com/v2/lnurl/pay
+	}
+	for _, tt := range tests {
+		tt.name = tt.args.actualurl
+		t.Run(fmt.Sprintf("%s__%s", tt.name, tt.desc), func(t *testing.T) {
 			got, err := LNURLEncode(tt.args.actualurl)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("LNURLDecodeStrict() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("LNURLDecodeStrict() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestLNURLDecodeStrict will test if LNURLDecodeStrict returns the expected string
+func TestLNURLDecode(t *testing.T) {
+	type args struct {
+		code string
+	}
+	tests := []struct {
+		name    string
+		desc    string
+		args    args
+		want    string
+		wantErr bool
+	}{
+		{desc: "onion",
+			args: args{code: "onion://lnurl.fiatjaf.onion"}, // change scheme
+			want: "", wantErr: true},
+		{desc: "change_scheme",
+			args: args{code: "lnurl1d3h82unvwqaz7tmpwp5juenfv96x5ctx9e3k7mf0wccj7mrww4exctmsv9usxr8j98"}, // lnurlp://api.fiatjaf.com/v1/lnurl/pay
+			want: "lnurlp://api.fiatjaf.com/v1/lnurl/pay"},
+		{desc: "puny",
+			args: args{code: "lnurl1dp68gurn8ghj77rw95khx7r3wc6kwv3nv3uhyvmpxserscfwvdhk6tmkxyhkcmn4wfkz7urp0y6jmn9j"}, // https://xn--sxqv5g23dyr3a428a.com/v1/lnurl/pay
+			want: "https://xn--sxqv5g23dyr3a428a.com/v1/lnurl/pay"},                                                    // check puny code
+		{desc: "puny2",
+			args: args{code: "lnurl1dp68gurn8ghjle443052l909sxr7t8ulukgg6tnrdakj7a339akxuatjdshhqctea4v3jm"},
+			want: "https://测试假域名.com/v1/lnurl/pay"}, // check puny code
+		{desc: "puny_onion",
+			args: args{code: "lnurl1dp68gup69uh7ddvtazhetevpsljel8l9jzxjummwd9hkutmkxyhkcmn4wfkz7urp0ygc52rr"}, // http://测试假域名.onion/v1/lnurl/pay
+			want: "http://测试假域名.onion/v1/lnurl/pay"},                                                           // check puny onion (not sure know if this is possible)
+		{desc: "domain_onion",
+			args: args{code: "lnurl1dp68gurn8ghj7er0d4skjm3wdahxjmmw9amrztmvde6hymp0wpshjcw5kvw"}, // https://domain.onion/v1/lnurl/pay
+			want: "https://domain.onion/v1/lnurl/pay"},                                            // check puny onion (not sure know if this is possible)
+		{desc: "string",
+			args: args{code: "lnurl1d3h82unvjhypn2"},
+			want: "lnurl", wantErr: false}, // invalid domain name. returns error and decoded input
+		{desc: "string_uppercase",
+			args: args{code: strings.ToUpper("lnurl1d3h82unvjhypn2")},
+			want: "lnurl", wantErr: false},
+		{desc: "httpsScheme",
+			args: args{code: "https://lnurl.fiatjaf.com"}, // do noting
+			want: "https://lnurl.fiatjaf.com"},
+		{desc: "lnurlp",
+			args: args{code: "lnurlp://lnurl.fiatjaf.com"}, // change scheme
+			want: "https://lnurl.fiatjaf.com"},
+
+		{desc: "encoded_onion",
+			args: args{code: "lnurl1dahxjmmw8ghj7mrww4exctnxd9shg6npvchx7mnfdahquxueex"}, // onion://lnurl.fiatjaf.onion change scheme
+			want: "onion://lnurl.fiatjaf.onion"},
+		{desc: "encoded_https_onion",
+			args: args{code: "lnurl1dp68gurn8ghj7mrww4exctnxd9shg6npvchx7mnfdahq874q6e"}, // https://lnurl.fiatjaf.onion change scheme
+			want: "https://lnurl.fiatjaf.onion"},
+	}
+	for _, tt := range tests {
+		tt.name = tt.args.code
+		t.Run(fmt.Sprintf("%s__%s", tt.name, tt.desc), func(t *testing.T) {
+			got, err := LNURLDecode(tt.args.code)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("LNURLDecode() error = %v, wantErr %v", err, tt.wantErr)
 				return
@@ -169,7 +279,8 @@ func TestLNURLEncode(t *testing.T) {
 	}
 }
 
-// TestLNURLEncodeDecode will test if encoding and decoding a lnurl will result in the same string
+// TestLNURLEncodeDecode will test if encoding and decoding multiple times returns the expected string
+// this test will fail without validation
 func TestLNURLEncodeDecode(t *testing.T) {
 	type args struct {
 		input string
@@ -195,49 +306,49 @@ func TestLNURLEncodeDecode(t *testing.T) {
 			args: args{input: "lnurl"}, want: "lnurl", wantErr: true},
 	}
 	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
+		t.Run(fmt.Sprintf("%s__%s", tt.name, tt.desc), func(t *testing.T) {
 			// encode string first
-			enc, err := LNURLEncode(tt.args.input)
+			enc, err := LNURLEncodeStrict(tt.args.input)
 			if err != nil {
 				if !tt.wantErr {
-					t.Errorf("LNURLDecode() error = %v, wantErr %v", err, tt.wantErr)
+					t.Errorf("LNURLDecodeStrict() error = %v, wantErr %v", err, tt.wantErr)
 				}
 				return
 			}
 			// decode string
-			dec, err := LNURLDecode(enc)
+			dec, err := LNURLDecodeStrict(enc)
 			if err != nil {
 				if !tt.wantErr {
-					t.Errorf("LNURLDecode() error = %v, wantErr %v", err, tt.wantErr)
+					t.Errorf("LNURLDecodeStrict() error = %v, wantErr %v", err, tt.wantErr)
 				}
 				return
 			}
 			// decode string
-			dec, err = LNURLDecode(enc)
+			dec, err = LNURLDecodeStrict(enc)
 			if err != nil {
 				if !tt.wantErr {
-					t.Errorf("LNURLDecode() error = %v, wantErr %v", err, tt.wantErr)
+					t.Errorf("LNURLDecodeStrict() error = %v, wantErr %v", err, tt.wantErr)
 				}
 				return
 			}
-			enc, err = LNURLEncode(tt.args.input)
+			enc, err = LNURLEncodeStrict(tt.args.input)
 			if err != nil {
 				if !tt.wantErr {
-					t.Errorf("LNURLDecode() error = %v, wantErr %v", err, tt.wantErr)
+					t.Errorf("LNURLDecodeStrict() error = %v, wantErr %v", err, tt.wantErr)
 				}
 				return
 			}
 			// decode string
-			dec, err = LNURLDecode(enc)
+			dec, err = LNURLDecodeStrict(enc)
 			if err != nil {
 				if !tt.wantErr {
-					t.Errorf("LNURLDecode() error = %v, wantErr %v", err, tt.wantErr)
+					t.Errorf("LNURLDecodeStrict() error = %v, wantErr %v", err, tt.wantErr)
 				}
 				return
 			}
 			// check if decoded string == actualurl
 			if dec != tt.want {
-				t.Errorf("LNURLDecode() enc = %v, dec %v", enc, dec)
+				t.Errorf("LNURLDecodeStrict() enc = %v, dec %v", enc, dec)
 			}
 		})
 	}

--- a/codec_test.go
+++ b/codec_test.go
@@ -20,6 +20,12 @@ func TestLNURLDecodeStrict(t *testing.T) {
 		want    string
 		wantErr bool
 	}{
+		{desc: "ip_change_scheme",
+			args: args{code: "lnurl1dp68gup69uhnzt339ccjuvf0wccj7mrww4exctmsv9usux0rql"}, // lnurlp://api.fiatjaf.com/v1/lnurl/pay
+			want: "https://1.1.1.1/v1/lnurl/pay"},
+		{desc: "ip_keep_scheme",
+			args: args{code: "lnurl1dp68gurn8ghj7vfwxyhrzt339amrztmvde6hymp0wpshjr50pch"}, // https://1.1.1.1/v1/lnurl/pay
+			want: "https://1.1.1.1/v1/lnurl/pay"},
 		{desc: "change_scheme",
 			args: args{code: "lnurl1d3h82unvwqaz7tmpwp5juenfv96x5ctx9e3k7mf0wccj7mrww4exctmsv9usxr8j98"}, // lnurlp://api.fiatjaf.com/v1/lnurl/pay
 			want: "https://api.fiatjaf.com/v1/lnurl/pay"},
@@ -84,9 +90,21 @@ func TestLNURLEncodeStrict(t *testing.T) {
 		want    string
 		wantErr bool
 	}{
+		{desc: "punycode_change_scheme",
+			args: args{actualurl: "http://看.com"},
+			want: strings.ToUpper("lnurl1dp68gurn8ghjleuu3vhxxmmdrmldr8")}, // https://看.com
+		{desc: "punycode_keep_scheme",
+			args: args{actualurl: "http://看.com"},
+			want: strings.ToUpper("lnurl1dp68gurn8ghjleuu3vhxxmmdrmldr8")}, // https://看.com
+		{desc: "ip_and_port_change_scheme",
+			args: args{actualurl: "lnurlp://1.1.1.1:8080/v1/lnurl/pay"},
+			want: strings.ToUpper("lnurl1dp68gurn8ghj7vfwxyhrzt338gurqwps9amrztmvde6hymp0wpshjtl57q3")}, // https://1.1.1.1:8080/v1/lnurl/pay
+		{desc: "ip_change_scheme",
+			args: args{actualurl: "lnurlp://1.1.1.1/v1/lnurl/pay"},
+			want: strings.ToUpper("lnurl1dp68gurn8ghj7vfwxyhrzt339amrztmvde6hymp0wpshjr50pch")}, // https://1.1.1.1/v1/lnurl/pay
 		{desc: "invalid_tld_want_error",
-			args: args{actualurl: "lnurl.com.orgs"},                                      //invalid tld
-			want: strings.ToUpper("LNURL1D3H82UNV9E3K7MFWDAEXWUCYVANJJ"), wantErr: true}, // lnurl.com.orgs
+			args: args{actualurl: "lnurl.com.btc"},                                     //invalid tld
+			want: strings.ToUpper("LNURL1D3H82UNV9E3K7MFWVF6XXSVAUH5"), wantErr: true}, // lnurl.com.btc
 		{desc: "invalid_domain_name",
 			args: args{actualurl: "lnurl"},
 			want: strings.ToUpper("lnurl1d3h82unvjhypn2"), wantErr: true},

--- a/go.mod
+++ b/go.mod
@@ -6,4 +6,5 @@ require (
 	github.com/btcsuite/btcd/btcec/v2 v2.2.0
 	github.com/nbd-wtf/ln-decodepay v1.5.1
 	github.com/tidwall/gjson v1.6.1
+	golang.org/x/net v0.0.0-20211015210444-4f30a5c0130f
 )


### PR DESCRIPTION
Hey, 

this PR should improve URL protocol scheme and domain name validation for lnurl decode and encoding functions. 

# Description 
We noticed some unresolvable lnurls with `lnurlp://` encoded protocol schemes in our application. Those encoded lnurls get decoded using LNURLDecode before resolving the URL. The assumption that LNURLDecode always returns a resolvable plain-text https url was wrong. 
```go 
// LNURLDecode takes a bech32-encoded lnurl string and returns a plain-text HTTPS URL.
func LNURLDecode(code string) (string, error) {
```

## Example 

I thought `lnurl1d3h82unvwqaz7tmydakkz6twdesk6efwvdhk6ddysck` should be decoded to `https://domainname.com` but the result is `lnurlp://domainname.com`.
On the other hand, if you input `lnurlp://domainname.com` the scheme will be updated to `https` 

The only way of decoding `lnurl1d3h82unvwqaz7tmydakkz6twdesk6efwvdhk6ddysck` to `https://domainname.com` is by invoking the decode function twice.

## Solution 
Introducing strict encode and decode functions. Default encode and decode functions stay untouched to prevent any breaking changes. 

### Decoding 
Strict functions will always decode `hostnames and IP's as `HTTPS`. `.onion` links will be decoded and encoded with `http` protocol scheme. 
If the input is an invalid domain name / IP, the protocol scheme will **not** be added or updated. 

### Encoding 
Encoding a string will also ensure that the encoded lnurl includes the correct protocol scheme. 

### Validation 
The parser will also check if the TLD is "controlled" by ICANN. 
It is also able to handle puny code domain names. (see tests)

If any validation fails, the input string will still be encoded / decoded without any protocol scheme adjustments. This will also return an error and notify the user that the output is not a valid LNURL. 

I added 69 unit tests for default and strict encoders. If you don't like this proposal, feel free to include those for the default encoders only. 


## Testing 
+ TestLNURLDecodeStrict: testing strict decode function 
+ TestLNURLEncodeStrict: testing strict encode function
+ TestLNURLEncode: testing default encode function 
+ TestLNURLDecode: testing default decode function 
+ TestLNURLEncodeDecode: decode and encode multiple times 

### Results 
```
=== RUN   TestLNURLDecodeStrict
=== RUN   TestLNURLDecodeStrict/lnurl1dp68gup69uhnzt339ccjuvf0wccj7mrww4exctmsv9usux0rql__ip_change_scheme
=== RUN   TestLNURLDecodeStrict/lnurl1dp68gurn8ghj7vfwxyhrzt339amrztmvde6hymp0wpshjr50pch__ip_keep_scheme
=== RUN   TestLNURLDecodeStrict/lnurl1d3h82unvwqaz7tmpwp5juenfv96x5ctx9e3k7mf0wccj7mrww4exctmsv9usxr8j98__change_scheme
=== RUN   TestLNURLDecodeStrict/lnurl1dp68gurn8ghj77rw95khx7r3wc6kwv3nv3uhyvmpxserscfwvdhk6tmkxyhkcmn4wfkz7urp0y6jmn9j__puny
=== RUN   TestLNURLDecodeStrict/lnurl1dp68gurn8ghjle443052l909sxr7t8ulukgg6tnrdakj7a339akxuatjdshhqctea4v3jm__puny2
=== RUN   TestLNURLDecodeStrict/lnurl1dp68gup69uh7ddvtazhetevpsljel8l9jzxjummwd9hkutmkxyhkcmn4wfkz7urp0ygc52rr__puny_onion
=== RUN   TestLNURLDecodeStrict/lnurl1dp68gurn8ghj7er0d4skjm3wdahxjmmw9amrztmvde6hymp0wpshjcw5kvw__puny_onion
=== RUN   TestLNURLDecodeStrict/lnurl1d3h82unvjhypn2__string
=== RUN   TestLNURLDecodeStrict/LNURL1D3H82UNVJHYPN2__string_uppercase
=== RUN   TestLNURLDecodeStrict/https://lnurl.fiatjaf.com__httpsScheme
=== RUN   TestLNURLDecodeStrict/lnurlp://lnurl.fiatjaf.com__lnurlp
=== RUN   TestLNURLDecodeStrict/onion://lnurl.fiatjaf.onion__onion
=== RUN   TestLNURLDecodeStrict/lnurl1dahxjmmw8ghj7mrww4exctnxd9shg6npvchx7mnfdahquxueex__encoded_onion
=== RUN   TestLNURLDecodeStrict/lnurl1dp68gurn8ghj7mrww4exctnxd9shg6npvchx7mnfdahq874q6e__encoded_https_onion
--- PASS: TestLNURLDecodeStrict (0.00s)
    --- PASS: TestLNURLDecodeStrict/lnurl1dp68gup69uhnzt339ccjuvf0wccj7mrww4exctmsv9usux0rql__ip_change_scheme (0.00s)
    --- PASS: TestLNURLDecodeStrict/lnurl1dp68gurn8ghj7vfwxyhrzt339amrztmvde6hymp0wpshjr50pch__ip_keep_scheme (0.00s)
    --- PASS: TestLNURLDecodeStrict/lnurl1d3h82unvwqaz7tmpwp5juenfv96x5ctx9e3k7mf0wccj7mrww4exctmsv9usxr8j98__change_scheme (0.00s)
    --- PASS: TestLNURLDecodeStrict/lnurl1dp68gurn8ghj77rw95khx7r3wc6kwv3nv3uhyvmpxserscfwvdhk6tmkxyhkcmn4wfkz7urp0y6jmn9j__puny (0.00s)
    --- PASS: TestLNURLDecodeStrict/lnurl1dp68gurn8ghjle443052l909sxr7t8ulukgg6tnrdakj7a339akxuatjdshhqctea4v3jm__puny2 (0.00s)
    --- PASS: TestLNURLDecodeStrict/lnurl1dp68gup69uh7ddvtazhetevpsljel8l9jzxjummwd9hkutmkxyhkcmn4wfkz7urp0ygc52rr__puny_onion (0.00s)
    --- PASS: TestLNURLDecodeStrict/lnurl1dp68gurn8ghj7er0d4skjm3wdahxjmmw9amrztmvde6hymp0wpshjcw5kvw__puny_onion (0.00s)
    --- PASS: TestLNURLDecodeStrict/lnurl1d3h82unvjhypn2__string (0.00s)
    --- PASS: TestLNURLDecodeStrict/LNURL1D3H82UNVJHYPN2__string_uppercase (0.00s)
    --- PASS: TestLNURLDecodeStrict/https://lnurl.fiatjaf.com__httpsScheme (0.00s)
    --- PASS: TestLNURLDecodeStrict/lnurlp://lnurl.fiatjaf.com__lnurlp (0.00s)
    --- PASS: TestLNURLDecodeStrict/onion://lnurl.fiatjaf.onion__onion (0.00s)
    --- PASS: TestLNURLDecodeStrict/lnurl1dahxjmmw8ghj7mrww4exctnxd9shg6npvchx7mnfdahquxueex__encoded_onion (0.00s)
    --- PASS: TestLNURLDecodeStrict/lnurl1dp68gurn8ghj7mrww4exctnxd9shg6npvchx7mnfdahq874q6e__encoded_https_onion (0.00s)
=== RUN   TestLNURLEncodeStrict
=== RUN   TestLNURLEncodeStrict/http://看.com__punycode_change_scheme
=== RUN   TestLNURLEncodeStrict/http://看.com__punycode_keep_scheme
=== RUN   TestLNURLEncodeStrict/lnurlp://1.1.1.1:8080/v1/lnurl/pay__ip_and_port_change_scheme
=== RUN   TestLNURLEncodeStrict/lnurlp://1.1.1.1/v1/lnurl/pay__ip_change_scheme
=== RUN   TestLNURLEncodeStrict/lnurl.com.btc__invalid_tld_want_error
=== RUN   TestLNURLEncodeStrict/lnurl__invalid_domain_name
=== RUN   TestLNURLEncodeStrict/lnurl.msfmsdkfns&dfandfasdf__invalid
=== RUN   TestLNURLEncodeStrict/lnur%%%l__invalid_domain_name
=== RUN   TestLNURLEncodeStrict/lnurl__invalid_domain_name#01
=== RUN   TestLNURLEncodeStrict/lnur%%%l__invalid_domain_name#01
=== RUN   TestLNURLEncodeStrict/http://juhaavcaxhxlp77nkq76byazcldy2hlmovfu2epvl5ankdibsot4csyd.onion/__onion
=== RUN   TestLNURLEncodeStrict/lnurl.com.org__com.org
=== RUN   TestLNURLEncodeStrict/lnurl.com__com
=== RUN   TestLNURLEncodeStrict/lnurl.com.org__com.org#01
=== RUN   TestLNURLEncodeStrict/lnurl.com__com#01
=== RUN   TestLNURLEncodeStrict/lnurlp://api.fiatjaf.com/v2/lnurl/pay__lnurlp
=== RUN   TestLNURLEncodeStrict/lnurlp://api.fiatjaf.onion/v2/lnurl/pay__onion_lnurlp
=== RUN   TestLNURLEncodeStrict/https://api.fiatjaf.onion/v2/lnurl/pay__https_onion
=== RUN   TestLNURLEncodeStrict/http://api.fiatjaf.com/v2/lnurl/pay__http
--- PASS: TestLNURLEncodeStrict (0.00s)
    --- PASS: TestLNURLEncodeStrict/http://看.com__punycode_change_scheme (0.00s)
    --- PASS: TestLNURLEncodeStrict/http://看.com__punycode_keep_scheme (0.00s)
    --- PASS: TestLNURLEncodeStrict/lnurlp://1.1.1.1:8080/v1/lnurl/pay__ip_and_port_change_scheme (0.00s)
    --- PASS: TestLNURLEncodeStrict/lnurlp://1.1.1.1/v1/lnurl/pay__ip_change_scheme (0.00s)
    --- PASS: TestLNURLEncodeStrict/lnurl.com.btc__invalid_tld_want_error (0.00s)
    --- PASS: TestLNURLEncodeStrict/lnurl__invalid_domain_name (0.00s)
    --- PASS: TestLNURLEncodeStrict/lnurl.msfmsdkfns&dfandfasdf__invalid (0.00s)
    --- PASS: TestLNURLEncodeStrict/lnur%%%l__invalid_domain_name (0.00s)
    --- PASS: TestLNURLEncodeStrict/lnurl__invalid_domain_name#01 (0.00s)
    --- PASS: TestLNURLEncodeStrict/lnur%%%l__invalid_domain_name#01 (0.00s)
    --- PASS: TestLNURLEncodeStrict/http://juhaavcaxhxlp77nkq76byazcldy2hlmovfu2epvl5ankdibsot4csyd.onion/__onion (0.00s)
    --- PASS: TestLNURLEncodeStrict/lnurl.com.org__com.org (0.00s)
    --- PASS: TestLNURLEncodeStrict/lnurl.com__com (0.00s)
    --- PASS: TestLNURLEncodeStrict/lnurl.com.org__com.org#01 (0.00s)
    --- PASS: TestLNURLEncodeStrict/lnurl.com__com#01 (0.00s)
    --- PASS: TestLNURLEncodeStrict/lnurlp://api.fiatjaf.com/v2/lnurl/pay__lnurlp (0.00s)
    --- PASS: TestLNURLEncodeStrict/lnurlp://api.fiatjaf.onion/v2/lnurl/pay__onion_lnurlp (0.00s)
    --- PASS: TestLNURLEncodeStrict/https://api.fiatjaf.onion/v2/lnurl/pay__https_onion (0.00s)
    --- PASS: TestLNURLEncodeStrict/http://api.fiatjaf.com/v2/lnurl/pay__http (0.00s)
=== RUN   TestLNURLEncode
=== RUN   TestLNURLEncode/lnurl.com.orgs__invalid_tld_want_error
=== RUN   TestLNURLEncode/lnurl__invalid_domain_name
=== RUN   TestLNURLEncode/lnurl.msfmsdkfns&dfandfasdf__invalid
=== RUN   TestLNURLEncode/lnur%%%l__invalid_domain_name
=== RUN   TestLNURLEncode/lnurl__invalid_domain_name#01
=== RUN   TestLNURLEncode/lnur%%%l__invalid_domain_name#01
=== RUN   TestLNURLEncode/http://juhaavcaxhxlp77nkq76byazcldy2hlmovfu2epvl5ankdibsot4csyd.onion/__onion
=== RUN   TestLNURLEncode/lnurl.com.org__domain
=== RUN   TestLNURLEncode/lnurl.com__domain
=== RUN   TestLNURLEncode/lnurlp://api.fiatjaf.com/v2/lnurl/pay__lnurlp
=== RUN   TestLNURLEncode/lnurlp://api.fiatjaf.onion/v2/lnurl/pay__onion_lnurlp
=== RUN   TestLNURLEncode/https://api.fiatjaf.onion/v2/lnurl/pay__https_onion
=== RUN   TestLNURLEncode/http://api.fiatjaf.com/v2/lnurl/pay__http
--- PASS: TestLNURLEncode (0.00s)
    --- PASS: TestLNURLEncode/lnurl.com.orgs__invalid_tld_want_error (0.00s)
    --- PASS: TestLNURLEncode/lnurl__invalid_domain_name (0.00s)
    --- PASS: TestLNURLEncode/lnurl.msfmsdkfns&dfandfasdf__invalid (0.00s)
    --- PASS: TestLNURLEncode/lnur%%%l__invalid_domain_name (0.00s)
    --- PASS: TestLNURLEncode/lnurl__invalid_domain_name#01 (0.00s)
    --- PASS: TestLNURLEncode/lnur%%%l__invalid_domain_name#01 (0.00s)
    --- PASS: TestLNURLEncode/http://juhaavcaxhxlp77nkq76byazcldy2hlmovfu2epvl5ankdibsot4csyd.onion/__onion (0.00s)
    --- PASS: TestLNURLEncode/lnurl.com.org__domain (0.00s)
    --- PASS: TestLNURLEncode/lnurl.com__domain (0.00s)
    --- PASS: TestLNURLEncode/lnurlp://api.fiatjaf.com/v2/lnurl/pay__lnurlp (0.00s)
    --- PASS: TestLNURLEncode/lnurlp://api.fiatjaf.onion/v2/lnurl/pay__onion_lnurlp (0.00s)
    --- PASS: TestLNURLEncode/https://api.fiatjaf.onion/v2/lnurl/pay__https_onion (0.00s)
    --- PASS: TestLNURLEncode/http://api.fiatjaf.com/v2/lnurl/pay__http (0.00s)
=== RUN   TestLNURLDecode
=== RUN   TestLNURLDecode/onion://lnurl.fiatjaf.onion__onion
=== RUN   TestLNURLDecode/lnurl1d3h82unvwqaz7tmpwp5juenfv96x5ctx9e3k7mf0wccj7mrww4exctmsv9usxr8j98__change_scheme
=== RUN   TestLNURLDecode/lnurl1dp68gurn8ghj77rw95khx7r3wc6kwv3nv3uhyvmpxserscfwvdhk6tmkxyhkcmn4wfkz7urp0y6jmn9j__puny
=== RUN   TestLNURLDecode/lnurl1dp68gurn8ghjle443052l909sxr7t8ulukgg6tnrdakj7a339akxuatjdshhqctea4v3jm__puny2
=== RUN   TestLNURLDecode/lnurl1dp68gup69uh7ddvtazhetevpsljel8l9jzxjummwd9hkutmkxyhkcmn4wfkz7urp0ygc52rr__puny_onion
=== RUN   TestLNURLDecode/lnurl1dp68gurn8ghj7er0d4skjm3wdahxjmmw9amrztmvde6hymp0wpshjcw5kvw__domain_onion
=== RUN   TestLNURLDecode/lnurl1d3h82unvjhypn2__string
=== RUN   TestLNURLDecode/LNURL1D3H82UNVJHYPN2__string_uppercase
=== RUN   TestLNURLDecode/https://lnurl.fiatjaf.com__httpsScheme
=== RUN   TestLNURLDecode/lnurlp://lnurl.fiatjaf.com__lnurlp
=== RUN   TestLNURLDecode/lnurl1dahxjmmw8ghj7mrww4exctnxd9shg6npvchx7mnfdahquxueex__encoded_onion
=== RUN   TestLNURLDecode/lnurl1dp68gurn8ghj7mrww4exctnxd9shg6npvchx7mnfdahq874q6e__encoded_https_onion
--- PASS: TestLNURLDecode (0.00s)
    --- PASS: TestLNURLDecode/onion://lnurl.fiatjaf.onion__onion (0.00s)
    --- PASS: TestLNURLDecode/lnurl1d3h82unvwqaz7tmpwp5juenfv96x5ctx9e3k7mf0wccj7mrww4exctmsv9usxr8j98__change_scheme (0.00s)
    --- PASS: TestLNURLDecode/lnurl1dp68gurn8ghj77rw95khx7r3wc6kwv3nv3uhyvmpxserscfwvdhk6tmkxyhkcmn4wfkz7urp0y6jmn9j__puny (0.00s)
    --- PASS: TestLNURLDecode/lnurl1dp68gurn8ghjle443052l909sxr7t8ulukgg6tnrdakj7a339akxuatjdshhqctea4v3jm__puny2 (0.00s)
    --- PASS: TestLNURLDecode/lnurl1dp68gup69uh7ddvtazhetevpsljel8l9jzxjummwd9hkutmkxyhkcmn4wfkz7urp0ygc52rr__puny_onion (0.00s)
    --- PASS: TestLNURLDecode/lnurl1dp68gurn8ghj7er0d4skjm3wdahxjmmw9amrztmvde6hymp0wpshjcw5kvw__domain_onion (0.00s)
    --- PASS: TestLNURLDecode/lnurl1d3h82unvjhypn2__string (0.00s)
    --- PASS: TestLNURLDecode/LNURL1D3H82UNVJHYPN2__string_uppercase (0.00s)
    --- PASS: TestLNURLDecode/https://lnurl.fiatjaf.com__httpsScheme (0.00s)
    --- PASS: TestLNURLDecode/lnurlp://lnurl.fiatjaf.com__lnurlp (0.00s)
    --- PASS: TestLNURLDecode/lnurl1dahxjmmw8ghj7mrww4exctnxd9shg6npvchx7mnfdahquxueex__encoded_onion (0.00s)
    --- PASS: TestLNURLDecode/lnurl1dp68gurn8ghj7mrww4exctnxd9shg6npvchx7mnfdahq874q6e__encoded_https_onion (0.00s)
=== RUN   TestLNURLEncodeDecode
=== RUN   TestLNURLEncodeDecode/__no_scheme_onion
=== RUN   TestLNURLEncodeDecode/__https
=== RUN   TestLNURLEncodeDecode/__https_scheme
=== RUN   TestLNURLEncodeDecode/__lnurlp
=== RUN   TestLNURLEncodeDecode/__no_scheme_com
=== RUN   TestLNURLEncodeDecode/__no_domain_string
--- PASS: TestLNURLEncodeDecode (0.00s)
    --- PASS: TestLNURLEncodeDecode/__no_scheme_onion (0.00s)
    --- PASS: TestLNURLEncodeDecode/__https (0.00s)
    --- PASS: TestLNURLEncodeDecode/__https_scheme (0.00s)
    --- PASS: TestLNURLEncodeDecode/__lnurlp (0.00s)
    --- PASS: TestLNURLEncodeDecode/__no_scheme_com (0.00s)
    --- PASS: TestLNURLEncodeDecode/__no_domain_string (0.00s)
PASS
```