### PR TITLE
added WithCustomClient

### DIFF
--- a/lnurl.go
+++ b/lnurl.go
@@ -17,6 +17,10 @@ var actualClient = &http.Client{
 
 type onioncapabletransport struct{}
 
+func WithCustomClient(c *http.Client) {
+	actualClient = c
+}
+
 func (_ onioncapabletransport) RoundTrip(r *http.Request) (*http.Response, error) {
 	if strings.HasSuffix(r.URL.Host, ".onion") && TorClient != nil {
 		return TorClient.Do(r)


### PR DESCRIPTION
Hey, 

this is a little convenience PR. 
Adding custom RoundTripper is currently possible, but you need to update TorClient and the default http.Client. 
Using HandleLNURL with a fully custom client is probably a great option. 
