### PR TITLE
Add strict codec

### DIFF
--- a/codec.go
+++ b/codec.go
@@ -11,8 +11,6 @@ import (
 )
 
 var lud17ValidSchemes = map[string]struct{}{"lnurla": {}, "lnurlp": {}, "lnurlw": {}, "lnurlc": {}, "keyauth": {}}
-var lud1ValidSchemes = map[string]struct{}{"https": {}}
-var lud1ValidOnionSchemes = map[string]struct{}{"http": {}}
 
 // LNURLDecode takes a bech32-encoded lnurl string and returns a plain-text https URL.
 func LNURLDecode(code string) (string, error) {
@@ -222,15 +220,6 @@ func setScheme(u *lnUrl) (updated bool) {
 
 func validLud17(schema string) bool {
 	_, ok := lud17ValidSchemes[schema]
-	return ok
-}
-
-func validLud1(schema string) bool {
-	_, ok := lud1ValidSchemes[schema]
-	return ok
-}
-func validLud1Onion(schema string) bool {
-	_, ok := lud1ValidOnionSchemes[schema]
 	return ok
 }
 

--- a/codec.go
+++ b/codec.go
@@ -51,7 +51,7 @@ func Parse(s string) (*LNURL, error) {
 	if err != nil {
 		return nil, err
 	}
-	psuf, icann := publicsuffix.PublicSuffix(dom)
+	psuf, icann := publicsuffix.PublicSuffix(tld)
 	return &LNURL{
 		Subdomain:    sub,
 		Domain:       domName,

--- a/codec.go
+++ b/codec.go
@@ -146,7 +146,8 @@ func domainPort(host string) (string, string) {
 	return host, ""
 }
 
-// LNURLDecode takes a bech32-encoded lnurl string and returns a plain-text https URL.
+// LNURLDecode takes a string and returns a valid lnurl, if possible.
+// code can be
 func LNURLDecodeStrict(code string) (string, error) {
 	code = strings.ToLower(code)
 	switch {
@@ -191,10 +192,11 @@ func LNURLDecodeStrict(code string) (string, error) {
 		if err != nil {
 			return "", err
 		}
-		lud17 := validLud17(u.Scheme)
+		scheme := u.Scheme
+		lud17 := validLud17(scheme)
 		if setScheme(u) {
 			if !lud17 {
-				return u.String(), fmt.Errorf("invalid scheme: %s", u.Scheme)
+				return u.String(), fmt.Errorf("invalid scheme: %s", scheme)
 			}
 		}
 		return u.String(), nil
@@ -218,11 +220,14 @@ func setScheme(u *lnUrl) (updated bool) {
 	return
 }
 
+// validLud17 will return true, if scheme is valid for lud17
 func validLud17(schema string) bool {
 	_, ok := lud17ValidSchemes[schema]
 	return ok
 }
 
+// LNURLEncodeStrict will encode the actualurl to lnurl.
+// based on the input url, it will determine whether bech32 encoding / url manipulation is necessary
 func LNURLEncodeStrict(actualurl string) (string, error) {
 	lnurl, err := parse(actualurl)
 	if err != nil {
@@ -289,7 +294,7 @@ func encode(s string) (string, error) {
 	return strings.ToUpper(lnurl), err
 }
 
-// isDomainName checks if a string is a presentation-format domain name
+// IsDomainName (from net package) checks if a string is a presentation-format domain name
 // (currently restricted to hostname-compatible "preferred name" LDH labels and
 // SRV-like "underscore labels"; see golang.org/issue/12421).
 func IsDomainName(s string) bool {

--- a/codec_test.go
+++ b/codec_test.go
@@ -109,7 +109,7 @@ func TestLNURLEncodeStrict(t *testing.T) {
 			args: args{actualurl: "lnurl"},
 			want: strings.ToUpper("lnurl1d3h82unvjhypn2"), wantErr: true},
 		{desc: "invalid",
-			args: args{actualurl: "lnurl.msfmsdkfns&dfandfasdf"},                                              // invalid TLD
+			args: args{actualurl: "lnurl.msfmsdkfns&dfandfasdf"},                                              // invalid tld
 			want: strings.ToUpper("LNURL1D3H82UNV9EKHXENDWDJXKENWWVNXGENPDEJXVCTNV3NQXM32ED"), wantErr: true}, // lnurl.msfmsdkfns&dfandfasdf
 		{desc: "invalid_domain_name",
 			args: args{actualurl: "lnur%%%l"},
@@ -184,7 +184,7 @@ func TestLNURLEncode(t *testing.T) {
 			args: args{actualurl: "lnurl"},
 			want: strings.ToUpper("lnurl1d3h82unvjhypn2"), wantErr: false},
 		{desc: "invalid",
-			args: args{actualurl: "lnurl.msfmsdkfns&dfandfasdf"},                                               // invalid TLD
+			args: args{actualurl: "lnurl.msfmsdkfns&dfandfasdf"},                                               // invalid tld
 			want: strings.ToUpper("LNURL1D3H82UNV9EKHXENDWDJXKENWWVNXGENPDEJXVCTNV3NQXM32ED"), wantErr: false}, // lnurl.msfmsdkfns&dfandfasdf
 		{desc: "invalid_domain_name",
 			args: args{actualurl: "lnur%%%l"},

--- a/codec_test.go
+++ b/codec_test.go
@@ -20,48 +20,51 @@ func TestLNURLDecodeStrict(t *testing.T) {
 		want    string
 		wantErr bool
 	}{
-		{desc: "ip_change_scheme",
-			args: args{code: "lnurl1dp68gup69uhnzt339ccjuvf0wccj7mrww4exctmsv9usux0rql"}, // lnurlp://api.fiatjaf.com/v1/lnurl/pay
-			want: "https://1.1.1.1/v1/lnurl/pay"},
-		{desc: "ip_keep_scheme",
-			args: args{code: "lnurl1dp68gurn8ghj7vfwxyhrzt339amrztmvde6hymp0wpshjr50pch"}, // https://1.1.1.1/v1/lnurl/pay
-			want: "https://1.1.1.1/v1/lnurl/pay"},
-		{desc: "change_scheme",
-			args: args{code: "lnurl1d3h82unvwqaz7tmpwp5juenfv96x5ctx9e3k7mf0wccj7mrww4exctmsv9usxr8j98"}, // lnurlp://api.fiatjaf.com/v1/lnurl/pay
-			want: "https://api.fiatjaf.com/v1/lnurl/pay"},
-		{desc: "puny",
-			args: args{code: "lnurl1dp68gurn8ghj77rw95khx7r3wc6kwv3nv3uhyvmpxserscfwvdhk6tmkxyhkcmn4wfkz7urp0y6jmn9j"}, // https://xn--sxqv5g23dyr3a428a.com/v1/lnurl/pay
-			want: "https://xn--sxqv5g23dyr3a428a.com/v1/lnurl/pay"},                                                    // check puny code
-		{desc: "puny2",
-			args: args{code: "lnurl1dp68gurn8ghjle443052l909sxr7t8ulukgg6tnrdakj7a339akxuatjdshhqctea4v3jm"},
-			want: "https://测试假域名.com/v1/lnurl/pay"}, // check puny code
-		{desc: "puny_onion",
-			args: args{code: "lnurl1dp68gup69uh7ddvtazhetevpsljel8l9jzxjummwd9hkutmkxyhkcmn4wfkz7urp0ygc52rr"}, // http://测试假域名.onion/v1/lnurl/pay
-			want: "http://测试假域名.onion/v1/lnurl/pay"},                                                           // check puny onion (not sure know if this is possible)
-		{desc: "puny_onion",
-			args: args{code: "lnurl1dp68gurn8ghj7er0d4skjm3wdahxjmmw9amrztmvde6hymp0wpshjcw5kvw"},
-			want: "http://domain.onion/v1/lnurl/pay"}, // check puny onion (not sure know if this is possible)
-		{desc: "string",
-			args: args{code: "lnurl1d3h82unvjhypn2"},
-			want: "lnurl", wantErr: true}, // invalid domain name. returns error and decoded input
-		{desc: "string_uppercase",
-			args: args{code: strings.ToUpper("lnurl1d3h82unvjhypn2")},
-			want: "lnurl", wantErr: true},
-		{desc: "httpsScheme",
-			args: args{code: "https://lnurl.fiatjaf.com"}, // do noting
-			want: "https://lnurl.fiatjaf.com"},
-		{desc: "lnurlp",
+		{desc: "LUD17_CHANGE_SCHEMA",
 			args: args{code: "lnurlp://lnurl.fiatjaf.com"}, // change scheme
 			want: "https://lnurl.fiatjaf.com"},
-		{desc: "onion",
+		{desc: "ONION_SCHEMA_CHANGE_SCHEMA_ERROR",
 			args: args{code: "onion://lnurl.fiatjaf.onion"}, // change scheme
-			want: "http://lnurl.fiatjaf.onion"},
-		{desc: "encoded_onion",
+			want: "http://lnurl.fiatjaf.onion", wantErr: true},
+		{desc: "LUD17_BECH32_ENCODED_CHANGE_SCHEMA_ERROR",
+			args: args{code: "lnurl1d3h82unvwqaz7tmpwp5juenfv96x5ctx9e3k7mf0wccj7mrww4exctmsv9usxr8j98"}, // lnurlp://api.fiatjaf.com/v1/lnurl/pay
+			want: "https://api.fiatjaf.com/v1/lnurl/pay", wantErr: true},
+		{desc: "LUD17_BECH32_ENCODED_CHANGE_SCHEMA_IP_ERROR",
+			args: args{code: "lnurl1dp68gup69uhnzt339ccjuvf0wccj7mrww4exctmsv9usux0rql"}, // lnurlp://api.fiatjaf.com/v1/lnurl/pay
+			want: "https://1.1.1.1/v1/lnurl/pay", wantErr: true},
+		{desc: "LUD1_ENCODED_CHANGE_SCHEMA",
+			args: args{code: "lnurl1dp68gurn8ghj7vfwxyhrzt339amrztmvde6hymp0wpshjr50pch"}, // https://1.1.1.1/v1/lnurl/pay
+			want: "https://1.1.1.1/v1/lnurl/pay"},
+		{desc: "LUD1_PUNY_SAME_SCHEMA",
+			args: args{code: "lnurl1dp68gurn8ghj77rw95khx7r3wc6kwv3nv3uhyvmpxserscfwvdhk6tmkxyhkcmn4wfkz7urp0y6jmn9j"}, // https://xn--sxqv5g23dyr3a428a.com/v1/lnurl/pay
+			want: "https://xn--sxqv5g23dyr3a428a.com/v1/lnurl/pay"},                                                    // check puny code
+		{desc: "LUD1_IDN_SAME_SCHEMA",
+			args: args{code: "lnurl1dp68gurn8ghjle443052l909sxr7t8ulukgg6tnrdakj7a339akxuatjdshhqctea4v3jm"},
+			want: "https://测试假域名.com/v1/lnurl/pay"}, // check puny code
+		{desc: "LUD17_BECH32_IDN_CHANGE_SCHEMA_ERROR",
+			args: args{code: "lnurl1d3h82unvwuaz7tlxkk973tu4ukqc0evlnljeprfwvdhk6tmkxyhkcmn4wfkz7urp0y93ltxj"},
+			want: "https://测试假域名.com/v1/lnurl/pay", wantErr: true}, // check puny code
+		{desc: "LUD1_BECH32_ONION_SAME_SCHEMA",
+			args: args{code: "lnurl1dp68gup69uh7ddvtazhetevpsljel8l9jzxjummwd9hkutmkxyhkcmn4wfkz7urp0ygc52rr"}, // http://测试假域名.onion/v1/lnurl/pay
+			want: "http://测试假域名.onion/v1/lnurl/pay"},                                                           // check puny onion (not sure know if this is possible)
+		{desc: "LUD1_BECH32_ONION_CHANGE_SCHEMA_ERROR",
+			args: args{code: "lnurl1dp68gurn8ghj7er0d4skjm3wdahxjmmw9amrztmvde6hymp0wpshjcw5kvw"},
+			want: "http://domain.onion/v1/lnurl/pay", wantErr: true}, // check puny onion (not sure know if this is possible)
+		{desc: "RANDOM_STRING_ERROR",
+			args: args{code: "lnurl1d3h82unvjhypn2"},
+			want: "lnurl", wantErr: true}, // invalid domain name. returns error and decoded input
+		{desc: "RANDOM_STRING_UPPERCASE_ERROR",
+			args: args{code: strings.ToUpper("lnurl1d3h82unvjhypn2")},
+			want: "lnurl", wantErr: true},
+		{desc: "HTTPS",
+			args: args{code: "https://lnurl.fiatjaf.com"}, // do noting
+			want: "https://lnurl.fiatjaf.com"},
+		{desc: "ONION_SCHEMA_CHANGE_SCHEMA_ERROR",
 			args: args{code: "lnurl1dahxjmmw8ghj7mrww4exctnxd9shg6npvchx7mnfdahquxueex"}, // change scheme
-			want: "http://lnurl.fiatjaf.onion"},
-		{desc: "encoded_https_onion",
+			want: "http://lnurl.fiatjaf.onion", wantErr: true},
+		{desc: "ONION_HTTPS_CHANGE_SCHEMA_ERROR",
 			args: args{code: "lnurl1dp68gurn8ghj7mrww4exctnxd9shg6npvchx7mnfdahq874q6e"}, // change scheme
-			want: "http://lnurl.fiatjaf.onion"},
+			want: "http://lnurl.fiatjaf.onion", wantErr: true},
 	}
 	for _, tt := range tests {
 		tt.name = tt.args.code
@@ -89,64 +92,57 @@ func TestLNURLEncodeStrict(t *testing.T) {
 		args    args
 		want    string
 		wantErr bool
-	}{
-		{desc: "punycode_change_scheme",
-			args: args{actualurl: "http://看.com"},
-			want: strings.ToUpper("lnurl1dp68gurn8ghjleuu3vhxxmmdrmldr8")}, // https://看.com
-		{desc: "punycode_keep_scheme",
-			args: args{actualurl: "http://看.com"},
-			want: strings.ToUpper("lnurl1dp68gurn8ghjleuu3vhxxmmdrmldr8")}, // https://看.com
-		{desc: "ip_and_port_change_scheme",
-			args: args{actualurl: "lnurlp://1.1.1.1:8080/v1/lnurl/pay"},
-			want: strings.ToUpper("lnurl1dp68gurn8ghj7vfwxyhrzt338gurqwps9amrztmvde6hymp0wpshjtl57q3")}, // https://1.1.1.1:8080/v1/lnurl/pay
-		{desc: "ip_change_scheme",
-			args: args{actualurl: "lnurlp://1.1.1.1/v1/lnurl/pay"},
-			want: strings.ToUpper("lnurl1dp68gurn8ghj7vfwxyhrzt339amrztmvde6hymp0wpshjr50pch")}, // https://1.1.1.1/v1/lnurl/pay
-		{desc: "invalid_tld_want_error",
-			args: args{actualurl: "lnurl.com.btc"},                                     //invalid tld
-			want: strings.ToUpper("LNURL1D3H82UNV9E3K7MFWVF6XXSVAUH5"), wantErr: true}, // lnurl.com.btc
-		{desc: "invalid_domain_name",
-			args: args{actualurl: "lnurl"},
-			want: strings.ToUpper("lnurl1d3h82unvjhypn2"), wantErr: true},
-		{desc: "invalid",
-			args: args{actualurl: "lnurl.msfmsdkfns&dfandfasdf"},                                              // invalid tld
-			want: strings.ToUpper("LNURL1D3H82UNV9EKHXENDWDJXKENWWVNXGENPDEJXVCTNV3NQXM32ED"), wantErr: true}, // lnurl.msfmsdkfns&dfandfasdf
-		{desc: "invalid_domain_name",
+	}{{desc: "ONION_SCHEME_ERROR",
+		args: args{actualurl: "onion://lnurl.com"},
+		want: strings.ToUpper("LNURL1DP68GURN8GHJ7MRWW4EXCTNRDAKS6NPC70"), wantErr: true},
+		{desc: "INVALID_DOMAIN_NAME_2_ERROR",
 			args: args{actualurl: "lnur%%%l"},
 			want: strings.ToUpper("lnurl1d3h82u39y5jkc45g4zl"), wantErr: true},
-		{desc: "invalid_domain_name",
+		{desc: "IDN_CHANGE_SCHEMA_ERROR",
+			args: args{actualurl: "http://看.com"},
+			want: strings.ToUpper("lnurl1dp68gurn8ghjleuu3vhxxmmdrmldr8"), wantErr: true}, // https://看.com
+		{desc: "NO_SCHEMA_INVALID_TLD_ERROR",
+			args: args{actualurl: "lnurl.com.btc"},                                     //invalid tld
+			want: strings.ToUpper("LNURL1D3H82UNV9E3K7MFWVF6XXSVAUH5"), wantErr: true}, // lnurl.com.btc
+		{desc: "INVALID_DOMAIN_NAME_ERROR",
 			args: args{actualurl: "lnurl"},
-			want: strings.ToUpper("lnurl1d3h82unvjhypn2"), wantErr: true}, // no domain validation
-		{desc: "invalid_domain_name",
-			args: args{actualurl: "lnur%%%l"},
-			want: strings.ToUpper("lnurl1d3h82u39y5jkc45g4zl"), wantErr: true}, // no domain validation
-		{desc: "onion",
+			want: strings.ToUpper("lnurl1d3h82unvjhypn2"), wantErr: true},
+		{desc: "INVALID_TLD_ERROR",
+			args: args{actualurl: "lnurl.msfmsdkfns&dfandfasdf"},                                              // invalid tld
+			want: strings.ToUpper("LNURL1D3H82UNV9EKHXENDWDJXKENWWVNXGENPDEJXVCTNV3NQXM32ED"), wantErr: true}, // lnurl.msfmsdkfns&dfandfasdf
+		{desc: "NO_SCHEMA_ERROR",
+			args: args{actualurl: "lnurl.com.org"},
+			want: strings.ToUpper("LNURL1DP68GURN8GHJ7MRWW4EXCTNRDAKJUMMJVUK5QJ46"), wantErr: true}, // https://lnurl.com.org,
+		{desc: "NO_SCHEMA_TLD_ERROR",
+			args: args{actualurl: "lnurl.com"},
+			want: "LNURL1DP68GURN8GHJ7MRWW4EXCTNRDAKS6NPC70", wantErr: true}, // https://lnurl.com
+		{desc: "COM_ORG_NO_SCHEMA",
+			args: args{actualurl: "lnurl.com.org"},
+			want: strings.ToUpper("LNURL1DP68GURN8GHJ7MRWW4EXCTNRDAKJUMMJVUK5QJ46"), wantErr: true}, // https://lnurl.com.org,
+		{desc: "LUD17_P_ONION",
+			args: args{actualurl: "lnurlp://api.fiatjaf.onion/v2/lnurl/pay"},
+			want: "lnurlp://api.fiatjaf.onion/v2/lnurl/pay"}, // http://api.fiatjaf.onion/v2/lnurl/pay
+		{desc: "LUD17_A_ONION",
+			args: args{actualurl: "lnurla://api.fiatjaf.onion/v2/lnurl/pay"},
+			want: "lnurla://api.fiatjaf.onion/v2/lnurl/pay"}, // http://api.fiatjaf.onion/v2/lnurl/pay
+		{desc: "LUD17_W_ONION",
+			args: args{actualurl: "lnurlw://api.fiatjaf.onion/v2/lnurl/pay"},
+			want: "lnurlw://api.fiatjaf.onion/v2/lnurl/pay"}, // https://api.fiatjaf.com/v2/lnurl/pay
+
+		{desc: "LUD17_IP_AND_PORT",
+			args: args{actualurl: "lnurlp://1.1.1.1:8080/v1/lnurl/pay"},
+			want: "lnurlp://1.1.1.1:8080/v1/lnurl/pay"}, // https://1.1.1.1:8080/v1/lnurl/pay
+		{desc: "LUD17_IP",
+			args: args{actualurl: "lnurlp://1.1.1.1/v1/lnurl/pay"},
+			want: "lnurlp://1.1.1.1/v1/lnurl/pay"}, // https://1.1.1.1/v1/lnurl/pay
+
+		{desc: "LUD1_ONION",
 			args: args{actualurl: "http://juhaavcaxhxlp77nkq76byazcldy2hlmovfu2epvl5ankdibsot4csyd.onion/"},
 			want: strings.ToUpper("lnurl1dp68gup69uhk5atgv9shvcmp0p58smrsxumku6m3xumxy7tp0f3kcerexf5xcmt0wen82vn9wpmxcdtpde4kg6tzwdhhgdrrwdukgtn0de5k7m30p4k848"), wantErr: false},
-		{desc: "com.org",
-			args: args{actualurl: "lnurl.com.org"},
-			want: strings.ToUpper("LNURL1DP68GURN8GHJ7MRWW4EXCTNRDAKJUMMJVUK5QJ46"), wantErr: false}, // https://lnurl.com.org,
-		{desc: "com",
-			args: args{actualurl: "lnurl.com"},
-			want: "LNURL1DP68GURN8GHJ7MRWW4EXCTNRDAKS6NPC70", wantErr: false}, // https://lnurl.com
-		{desc: "com.org",
-			args: args{actualurl: "lnurl.com.org"},
-			want: strings.ToUpper("LNURL1DP68GURN8GHJ7MRWW4EXCTNRDAKJUMMJVUK5QJ46"), wantErr: false}, // https://lnurl.com.org,
-		{desc: "com",
-			args: args{actualurl: "lnurl.com"},
-			want: "LNURL1DP68GURN8GHJ7MRWW4EXCTNRDAKS6NPC70", wantErr: false}, // https://lnurl.com
-		{desc: "lnurlp",
-			args: args{actualurl: "lnurlp://api.fiatjaf.com/v2/lnurl/pay"},
-			want: "LNURL1DP68GURN8GHJ7CTSDYHXV6TPW34XZE3WVDHK6TMKXGHKCMN4WFKZ7URP0Y0Q3PEG"}, // https://api.fiatjaf.com/v2/lnurl/pay
-		{desc: "onion_lnurlp",
-			args: args{actualurl: "lnurlp://api.fiatjaf.onion/v2/lnurl/pay"},
-			want: "LNURL1DP68GUP69UHKZURF9ENXJCT5DFSKVTN0DE5K7M30WCEZ7MRWW4EXCTMSV9USWEVHQG"}, // http://api.fiatjaf.onion/v2/lnurl/pay
-		{desc: "https_onion",
-			args: args{actualurl: "https://api.fiatjaf.onion/v2/lnurl/pay"},
-			want: "LNURL1DP68GUP69UHKZURF9ENXJCT5DFSKVTN0DE5K7M30WCEZ7MRWW4EXCTMSV9USWEVHQG"}, // http://api.fiatjaf.onion/v2/lnurl/pay
-		{desc: "http",
-			args: args{actualurl: "http://api.fiatjaf.com/v2/lnurl/pay"},
-			want: "LNURL1DP68GURN8GHJ7CTSDYHXV6TPW34XZE3WVDHK6TMKXGHKCMN4WFKZ7URP0Y0Q3PEG"}, // https://api.fiatjaf.com/v2/lnurl/pay
+		{desc: "HTTP",
+			args: args{actualurl: "https://api.fiatjaf.com/v2/lnurl/pay"},
+			want: strings.ToUpper("lnurl1dp68gurn8ghj7ctsdyhxv6tpw34xze3wvdhk6tmkxghkcmn4wfkz7urp0y0q3peg")}, // https://api.fiatjaf.com/v2/lnurl/pay
+
 	}
 	for _, tt := range tests {
 		tt.name = tt.args.actualurl
@@ -319,7 +315,7 @@ func TestLNURLEncodeDecode(t *testing.T) {
 		{desc: "lnurlp",
 			args: args{input: "lnurlp://lnurl.fiatjaf.com"}, want: "https://lnurl.fiatjaf.com"}, // will be encoded to https://
 		{desc: "no_scheme_com",
-			args: args{input: "lnurl.fiatjaf.com"}, want: "https://lnurl.fiatjaf.com"},
+			args: args{input: "lnurl.fiatjaf.com"}, want: "https://lnurl.fiatjaf.com", wantErr: true},
 		{desc: "no_domain_string",
 			args: args{input: "lnurl"}, want: "lnurl", wantErr: true},
 	}

--- a/codec_test.go
+++ b/codec_test.go
@@ -1,0 +1,218 @@
+package lnurl
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestLNURLDecode will test if LNURLDecode returns the expected string
+func TestLNURLDecode(t *testing.T) {
+	type args struct {
+		code string
+	}
+	tests := []struct {
+		name    string
+		desc    string
+		args    args
+		want    string
+		wantErr bool
+	}{
+		{desc: "simple",
+			args: args{code: "lnurl1d3h82unvwqaz7tmpwp5juenfv96x5ctx9e3k7mf0wccj7mrww4exctmsv9usxr8j98"},
+			want: "https://api.fiatjaf.com/v1/lnurl/pay"},
+		{desc: "puny",
+			args: args{code: "lnurl1dp68gurn8ghj77rw95khx7r3wc6kwv3nv3uhyvmpxserscfwvdhk6tmkxyhkcmn4wfkz7urp0y6jmn9j"},
+			want: "https://xn--sxqv5g23dyr3a428a.com/v1/lnurl/pay"}, // check puny code
+		{desc: "puny2",
+			args: args{code: "lnurl1dp68gurn8ghjle443052l909sxr7t8ulukgg6tnrdakj7a339akxuatjdshhqctea4v3jm"},
+			want: "https://测试假域名.com/v1/lnurl/pay"}, // check puny code
+		{desc: "puny_onion",
+			args: args{code: "lnurl1dp68gup69uh7ddvtazhetevpsljel8l9jzxjummwd9hkutmkxyhkcmn4wfkz7urp0ygc52rr"},
+			want: "http://测试假域名.onion/v1/lnurl/pay"}, // check puny onion (not sure know if this is possible)
+		{desc: "string",
+			args: args{code: "lnurl1d3h82unvjhypn2"},
+			want: "lnurl", wantErr: true}, // invalid domain name. returns error and decoded input
+		{desc: "string_uppercase",
+			args: args{code: strings.ToUpper("lnurl1d3h82unvjhypn2")},
+			want: "lnurl", wantErr: true},
+		{desc: "httpsScheme",
+			args: args{code: "https://lnurl.fiatjaf.com"}, // do noting
+			want: "https://lnurl.fiatjaf.com"},
+		{desc: "lnurlp",
+			args: args{code: "lnurlp://lnurl.fiatjaf.com"}, // change scheme
+			want: "https://lnurl.fiatjaf.com"},
+		{desc: "onion",
+			args: args{code: "onion://lnurl.fiatjaf.onion"}, // change scheme
+			want: "http://lnurl.fiatjaf.onion"},
+		{desc: "encoded_onion",
+			args: args{code: "lnurl1dahxjmmw8ghj7mrww4exctnxd9shg6npvchx7mnfdahquxueex"}, // change scheme
+			want: "http://lnurl.fiatjaf.onion"},
+		{desc: "encoded_https_onion",
+			args: args{code: "lnurl1dp68gurn8ghj7mrww4exctnxd9shg6npvchx7mnfdahq874q6e"}, // change scheme
+			want: "http://lnurl.fiatjaf.onion"},
+	}
+	for _, tt := range tests {
+		tt.name = tt.args.code
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := LNURLDecode(tt.args.code)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("LNURLDecode() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("LNURLDecode() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestLNURLEncodeWithValidation(t *testing.T) {
+	type args struct {
+		actualurl string
+	}
+	tests := []struct {
+		name    string
+		desc    string
+		args    args
+		want    string
+		wantErr bool
+	}{
+		{desc: "com.org_invalid",
+			args: args{actualurl: "lnurl.com.orgs"},                                      //invalid tld
+			want: strings.ToUpper("LNURL1D3H82UNV9E3K7MFWDAEXWUCYVANJJ"), wantErr: true}, // lnurl.com.orgs
+		{desc: "onion",
+			args: args{actualurl: "http://juhaavcaxhxlp77nkq76byazcldy2hlmovfu2epvl5ankdibsot4csyd.onion/"},                                                                        //invalid tld
+			want: strings.ToUpper("lnurl1dp68gup69uhk5atgv9shvcmp0p58smrsxumku6m3xumxy7tp0f3kcerexf5xcmt0wen82vn9wpmxcdtpde4kg6tzwdhhgdrrwdukgtn0de5k7m30p4k848"), wantErr: false}, // lnurl.com.orgs
+		{desc: "invalid",
+			args: args{actualurl: "lnurl.msfmsdkfns&dfandfasdf"},                                              // invalid TLD
+			want: strings.ToUpper("LNURL1D3H82UNV9EKHXENDWDJXKENWWVNXGENPDEJXVCTNV3NQXM32ED"), wantErr: true}, // lnurl.msfmsdkfns&dfandfasdf
+		{desc: "com.org",
+			args: args{actualurl: "lnurl.com.org"},
+			want: strings.ToUpper("LNURL1DP68GURN8GHJ7MRWW4EXCTNRDAKJUMMJVUK5QJ46"), wantErr: false}, // https://lnurl.com.org,
+		{desc: "invalid_domain_name",
+			args: args{actualurl: "lnurl"},
+			want: strings.ToUpper("lnurl1d3h82unvjhypn2"), wantErr: true},
+		{desc: "invalid_domain_name",
+			args: args{actualurl: "lnur%%%l"},
+			want: strings.ToUpper("lnurl1d3h82u39y5jkc45g4zl"), wantErr: true},
+		{desc: "com",
+			args: args{actualurl: "lnurl.com"},
+			want: "LNURL1DP68GURN8GHJ7MRWW4EXCTNRDAKS6NPC70", wantErr: false}, // https://lnurl.com
+	}
+	for _, tt := range tests {
+		tt.name = tt.args.actualurl
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := LNURLEncodeWithValidation(tt.args.actualurl)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("LNURLDecode() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("LNURLDecode() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestLNURLDecode will test if LNURLDecode returns the expected string
+func TestLNURLEncode(t *testing.T) {
+	type args struct {
+		actualurl string
+	}
+	tests := []struct {
+		name    string
+		desc    string
+		args    args
+		want    string
+		wantErr bool
+	}{
+		{desc: "com.org",
+			args: args{actualurl: "lnurl.com.org"},
+			want: strings.ToUpper("LNURL1DP68GURN8GHJ7MRWW4EXCTNRDAKJUMMJVUK5QJ46"), wantErr: false}, // https://lnurl.com.org,
+		{desc: "invalid_domain_name",
+			args: args{actualurl: "lnurl"},
+			want: strings.ToUpper("lnurl1d3h82unvjhypn2"), wantErr: false}, // no domain validation
+		{desc: "invalid_domain_name",
+			args: args{actualurl: "lnur%%%l"},
+			want: strings.ToUpper("lnurl1d3h82u39y5jkc45g4zl"), wantErr: false}, // no domain validation
+		{desc: "com",
+			args: args{actualurl: "lnurl.com"},
+			want: "LNURL1DP68GURN8GHJ7MRWW4EXCTNRDAKS6NPC70", wantErr: false}, // https://lnurl.com
+		{desc: "lnurlp",
+			args: args{actualurl: "lnurlp://api.fiatjaf.com/v2/lnurl/pay"},
+			want: "LNURL1DP68GURN8GHJ7CTSDYHXV6TPW34XZE3WVDHK6TMKXGHKCMN4WFKZ7URP0Y0Q3PEG"}, // https://api.fiatjaf.com/v2/lnurl/pay
+		{desc: "onion_lnurlp",
+			args: args{actualurl: "lnurlp://api.fiatjaf.onion/v2/lnurl/pay"},
+			want: "LNURL1DP68GUP69UHKZURF9ENXJCT5DFSKVTN0DE5K7M30WCEZ7MRWW4EXCTMSV9USWEVHQG"}, // http://api.fiatjaf.onion/v2/lnurl/pay
+		{desc: "https_onion",
+			args: args{actualurl: "https://api.fiatjaf.onion/v2/lnurl/pay"},
+			want: "LNURL1DP68GUP69UHKZURF9ENXJCT5DFSKVTN0DE5K7M30WCEZ7MRWW4EXCTMSV9USWEVHQG"}, // http://api.fiatjaf.onion/v2/lnurl/pay
+		{desc: "http",
+			args: args{actualurl: "http://api.fiatjaf.com/v2/lnurl/pay"},
+			want: "LNURL1DP68GURN8GHJ7CTSDYHXV6TPW34XZE3WVDHK6TMKXGHKCMN4WFKZ7URP0Y0Q3PEG"}, // https://api.fiatjaf.com/v2/lnurl/pay
+	}
+	for _, tt := range tests {
+		tt.name = tt.args.actualurl
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := LNURLEncode(tt.args.actualurl)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("LNURLDecode() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("LNURLDecode() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestLNURLEncodeDecode will test if encoding and decoding a lnurl will result in the same string
+func TestLNURLEncodeDecode(t *testing.T) {
+	type args struct {
+		input string
+	}
+	tests := []struct {
+		desc    string
+		name    string
+		args    args
+		wantErr bool
+		want    string
+	}{
+		{desc: "no_scheme_onion",
+			args: args{input: "hellosir.onion"}, wantErr: true, want: "http://hellosir.onion"}, // will be encoded to http://
+		{desc: "https",
+			args: args{input: "https://api.fiatjaf.com/v1/lnurl/pay"}, want: "https://api.fiatjaf.com/v1/lnurl/pay"},
+		{desc: "https_scheme",
+			args: args{input: "https://lnurl.fiatjaf.com"}, want: "https://lnurl.fiatjaf.com"},
+		{desc: "lnurlp",
+			args: args{input: "lnurlp://lnurl.fiatjaf.com"}, want: "https://lnurl.fiatjaf.com"}, // will be encoded to https://
+		{desc: "no_scheme_com",
+			args: args{input: "lnurl.fiatjaf.com"}, want: "https://lnurl.fiatjaf.com"},
+		{desc: "no_domain_string",
+			args: args{input: "lnurl"}, want: "lnurl", wantErr: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// encode string first
+			enc, err := LNURLEncode(tt.args.input)
+			if err != nil {
+				if !tt.wantErr {
+					t.Errorf("LNURLDecode() error = %v, wantErr %v", err, tt.wantErr)
+				}
+				return
+			}
+			// decode string
+			dec, err := LNURLDecode(enc)
+			if err != nil {
+				if !tt.wantErr {
+					t.Errorf("LNURLDecode() error = %v, wantErr %v", err, tt.wantErr)
+				}
+				return
+			}
+			// check if decoded string == actualurl
+			if dec != tt.want {
+				t.Errorf("LNURLDecode() enc = %v, dec %v", enc, dec)
+			}
+		})
+	}
+}

--- a/codec_test.go
+++ b/codec_test.go
@@ -17,18 +17,21 @@ func TestLNURLDecode(t *testing.T) {
 		want    string
 		wantErr bool
 	}{
-		{desc: "simple",
-			args: args{code: "lnurl1d3h82unvwqaz7tmpwp5juenfv96x5ctx9e3k7mf0wccj7mrww4exctmsv9usxr8j98"},
+		{desc: "change_scheme",
+			args: args{code: "lnurl1d3h82unvwqaz7tmpwp5juenfv96x5ctx9e3k7mf0wccj7mrww4exctmsv9usxr8j98"}, // lnurlp://api.fiatjaf.com/v1/lnurl/pay
 			want: "https://api.fiatjaf.com/v1/lnurl/pay"},
 		{desc: "puny",
-			args: args{code: "lnurl1dp68gurn8ghj77rw95khx7r3wc6kwv3nv3uhyvmpxserscfwvdhk6tmkxyhkcmn4wfkz7urp0y6jmn9j"},
-			want: "https://xn--sxqv5g23dyr3a428a.com/v1/lnurl/pay"}, // check puny code
+			args: args{code: "lnurl1dp68gurn8ghj77rw95khx7r3wc6kwv3nv3uhyvmpxserscfwvdhk6tmkxyhkcmn4wfkz7urp0y6jmn9j"}, // https://xn--sxqv5g23dyr3a428a.com/v1/lnurl/pay
+			want: "https://xn--sxqv5g23dyr3a428a.com/v1/lnurl/pay"},                                                    // check puny code
 		{desc: "puny2",
 			args: args{code: "lnurl1dp68gurn8ghjle443052l909sxr7t8ulukgg6tnrdakj7a339akxuatjdshhqctea4v3jm"},
 			want: "https://测试假域名.com/v1/lnurl/pay"}, // check puny code
 		{desc: "puny_onion",
 			args: args{code: "lnurl1dp68gup69uh7ddvtazhetevpsljel8l9jzxjummwd9hkutmkxyhkcmn4wfkz7urp0ygc52rr"},
 			want: "http://测试假域名.onion/v1/lnurl/pay"}, // check puny onion (not sure know if this is possible)
+		{desc: "puny_onion",
+			args: args{code: "lnurl1dp68gurn8ghj7er0d4skjm3wdahxjmmw9amrztmvde6hymp0wpshjcw5kvw"},
+			want: "http://domain.onion/v1/lnurl/pay"}, // check puny onion (not sure know if this is possible)
 		{desc: "string",
 			args: args{code: "lnurl1d3h82unvjhypn2"},
 			want: "lnurl", wantErr: true}, // invalid domain name. returns error and decoded input
@@ -203,6 +206,29 @@ func TestLNURLEncodeDecode(t *testing.T) {
 			}
 			// decode string
 			dec, err := LNURLDecode(enc)
+			if err != nil {
+				if !tt.wantErr {
+					t.Errorf("LNURLDecode() error = %v, wantErr %v", err, tt.wantErr)
+				}
+				return
+			}
+			// decode string
+			dec, err = LNURLDecode(enc)
+			if err != nil {
+				if !tt.wantErr {
+					t.Errorf("LNURLDecode() error = %v, wantErr %v", err, tt.wantErr)
+				}
+				return
+			}
+			enc, err = LNURLEncode(tt.args.input)
+			if err != nil {
+				if !tt.wantErr {
+					t.Errorf("LNURLDecode() error = %v, wantErr %v", err, tt.wantErr)
+				}
+				return
+			}
+			// decode string
+			dec, err = LNURLDecode(enc)
 			if err != nil {
 				if !tt.wantErr {
 					t.Errorf("LNURLDecode() error = %v, wantErr %v", err, tt.wantErr)

--- a/codec_test.go
+++ b/codec_test.go
@@ -68,7 +68,7 @@ func TestLNURLDecodeStrict(t *testing.T) {
 	}
 	for _, tt := range tests {
 		tt.name = tt.args.code
-		t.Run(fmt.Sprintf("%s__%s", tt.name, tt.desc), func(t *testing.T) {
+		t.Run(fmt.Sprintf("%s", tt.desc), func(t *testing.T) {
 			got, err := LNURLDecodeStrict(tt.args.code)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("LNURLDecodeStrict() error = %v, wantErr %v", err, tt.wantErr)
@@ -92,9 +92,15 @@ func TestLNURLEncodeStrict(t *testing.T) {
 		args    args
 		want    string
 		wantErr bool
-	}{{desc: "ONION_SCHEME_ERROR",
-		args: args{actualurl: "onion://lnurl.com"},
-		want: strings.ToUpper("LNURL1DP68GURN8GHJ7MRWW4EXCTNRDAKS6NPC70"), wantErr: true},
+	}{{desc: "INVALID_IP_ERROR",
+		args: args{actualurl: "onion://10.2.0.10:8888"},
+		want: strings.ToUpper("LNURL1DP68GURN8GHJ7VFS9CEZUVPWXYCR5WPC8QUQAPPZPR"), wantErr: false},
+		{desc: "INVALID_IP_ERROR",
+			args: args{actualurl: "onion://111.2.999.2:88"},
+			want: strings.ToUpper("lnurl1dahxjmmw8ghj7vf3xyhryt3e8yujuv368quq39nwhr"), wantErr: true},
+		{desc: "ONION_SCHEME_ERROR",
+			args: args{actualurl: "onion://lnurl.com"},
+			want: strings.ToUpper("LNURL1DP68GURN8GHJ7MRWW4EXCTNRDAKS6NPC70"), wantErr: true},
 		{desc: "INVALID_DOMAIN_NAME_2_ERROR",
 			args: args{actualurl: "lnur%%%l"},
 			want: strings.ToUpper("lnurl1d3h82u39y5jkc45g4zl"), wantErr: true},
@@ -110,13 +116,13 @@ func TestLNURLEncodeStrict(t *testing.T) {
 		{desc: "INVALID_TLD_ERROR",
 			args: args{actualurl: "lnurl.msfmsdkfns&dfandfasdf"},                                              // invalid tld
 			want: strings.ToUpper("LNURL1D3H82UNV9EKHXENDWDJXKENWWVNXGENPDEJXVCTNV3NQXM32ED"), wantErr: true}, // lnurl.msfmsdkfns&dfandfasdf
-		{desc: "NO_SCHEMA_ERROR",
+		{desc: "ADD_SCHEMA_COM_ORG",
 			args: args{actualurl: "lnurl.com.org"},
 			want: strings.ToUpper("LNURL1DP68GURN8GHJ7MRWW4EXCTNRDAKJUMMJVUK5QJ46"), wantErr: true}, // https://lnurl.com.org,
-		{desc: "NO_SCHEMA_TLD_ERROR",
+		{desc: "ADD_SCHEMA_COM",
 			args: args{actualurl: "lnurl.com"},
 			want: "LNURL1DP68GURN8GHJ7MRWW4EXCTNRDAKS6NPC70", wantErr: true}, // https://lnurl.com
-		{desc: "COM_ORG_NO_SCHEMA",
+		{desc: "COM_ORG_ADD_SCHEMA",
 			args: args{actualurl: "lnurl.com.org"},
 			want: strings.ToUpper("LNURL1DP68GURN8GHJ7MRWW4EXCTNRDAKJUMMJVUK5QJ46"), wantErr: true}, // https://lnurl.com.org,
 		{desc: "LUD17_P_ONION",
@@ -139,14 +145,14 @@ func TestLNURLEncodeStrict(t *testing.T) {
 		{desc: "LUD1_ONION",
 			args: args{actualurl: "http://juhaavcaxhxlp77nkq76byazcldy2hlmovfu2epvl5ankdibsot4csyd.onion/"},
 			want: strings.ToUpper("lnurl1dp68gup69uhk5atgv9shvcmp0p58smrsxumku6m3xumxy7tp0f3kcerexf5xcmt0wen82vn9wpmxcdtpde4kg6tzwdhhgdrrwdukgtn0de5k7m30p4k848"), wantErr: false},
-		{desc: "HTTP",
+		{desc: "HTTPS",
 			args: args{actualurl: "https://api.fiatjaf.com/v2/lnurl/pay"},
 			want: strings.ToUpper("lnurl1dp68gurn8ghj7ctsdyhxv6tpw34xze3wvdhk6tmkxghkcmn4wfkz7urp0y0q3peg")}, // https://api.fiatjaf.com/v2/lnurl/pay
 
 	}
 	for _, tt := range tests {
 		tt.name = tt.args.actualurl
-		t.Run(fmt.Sprintf("%s__%s", tt.name, tt.desc), func(t *testing.T) {
+		t.Run(fmt.Sprintf("%s", tt.desc), func(t *testing.T) {
 			got, err := LNURLEncodeStrict(tt.args.actualurl)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("LNURLDecodeStrict() error = %v, wantErr %v", err, tt.wantErr)
@@ -172,50 +178,63 @@ func TestLNURLEncode(t *testing.T) {
 		args    args
 		want    string
 		wantErr bool
-	}{
-		{desc: "invalid_tld_want_error",
-			args: args{actualurl: "lnurl.com.orgs"},                                       //invalid tld
-			want: strings.ToUpper("LNURL1D3H82UNV9E3K7MFWDAEXWUCYVANJJ"), wantErr: false}, // lnurl.com.orgs
-		{desc: "invalid_domain_name",
-			args: args{actualurl: "lnurl"},
-			want: strings.ToUpper("lnurl1d3h82unvjhypn2"), wantErr: false},
-		{desc: "invalid",
-			args: args{actualurl: "lnurl.msfmsdkfns&dfandfasdf"},                                               // invalid tld
-			want: strings.ToUpper("LNURL1D3H82UNV9EKHXENDWDJXKENWWVNXGENPDEJXVCTNV3NQXM32ED"), wantErr: false}, // lnurl.msfmsdkfns&dfandfasdf
-		{desc: "invalid_domain_name",
+	}{{desc: "INVALID_IP_NO_ERROR",
+		args: args{actualurl: "onion://111.2.999.2:88"},
+		want: strings.ToUpper("lnurl1dahxjmmw8ghj7vf3xyhryt3e8yujuv368quq39nwhr"), wantErr: false},
+		{desc: "ONION_SCHEME_NO_CHANGE",
+			args: args{actualurl: "onion://lnurl.com"},
+			want: strings.ToUpper("LNURL1DAHXJMMW8GHJ7MRWW4EXCTNRDAKSU44R9H"), wantErr: false},
+		{desc: "INVALID_DOMAIN_NAME_2_ERROR",
 			args: args{actualurl: "lnur%%%l"},
 			want: strings.ToUpper("lnurl1d3h82u39y5jkc45g4zl"), wantErr: false},
-		{desc: "invalid_domain_name",
+		{desc: "IDN_NO_CHANGE_SCHEMA_ERROR",
+			args: args{actualurl: "http://看.com"},
+			want: strings.ToUpper("LNURL1DP68GUP69UH708YT9E3K7MGL572TH"), wantErr: false}, // http://看.com
+		{desc: "NO_SCHEMA_INVALID_TLD_NO_ERROR",
+			args: args{actualurl: "lnurl.com.btc"},                                      //invalid tld
+			want: strings.ToUpper("LNURL1D3H82UNV9E3K7MFWVF6XXSVAUH5"), wantErr: false}, // lnurl.com.btc
+		{desc: "NO_SCHEMA_INVALID_TLD_NO_ERROR_2",
+			args: args{actualurl: "https://lnurl.com.btc"},                                           //invalid tld
+			want: strings.ToUpper("LNURL1DP68GURN8GHJ7MRWW4EXCTNRDAKJUCN5VVXPFXPM"), wantErr: false}, // lnurl.com.btc
+		{desc: "INVALID_DOMAIN_NAME_ERROR",
 			args: args{actualurl: "lnurl"},
-			want: strings.ToUpper("lnurl1d3h82unvjhypn2"), wantErr: false}, // no domain validation
-		{desc: "invalid_domain_name",
-			args: args{actualurl: "lnur%%%l"},
-			want: strings.ToUpper("lnurl1d3h82u39y5jkc45g4zl"), wantErr: false}, // no domain validation
-		{desc: "onion",
-			args: args{actualurl: "http://juhaavcaxhxlp77nkq76byazcldy2hlmovfu2epvl5ankdibsot4csyd.onion/"},
-			want: strings.ToUpper("lnurl1dp68gup69uhk5atgv9shvcmp0p58smrsxumku6m3xumxy7tp0f3kcerexf5xcmt0wen82vn9wpmxcdtpde4kg6tzwdhhgdrrwdukgtn0de5k7m30p4k848"), wantErr: false}, // http://juhaavcaxhxlp77nkq76byazcldy2hlmovfu2epvl5ankdibsot4csyd.onion/
-		{desc: "domain",
+			want: strings.ToUpper("lnurl1d3h82unvjhypn2"), wantErr: false},
+		{desc: "INVALID_TLD_ERROR",
+			args: args{actualurl: "lnurl.msfmsdkfns&dfandfasdf"},                                               // invalid tld
+			want: strings.ToUpper("LNURL1D3H82UNV9EKHXENDWDJXKENWWVNXGENPDEJXVCTNV3NQXM32ED"), wantErr: false}, // lnurl.msfmsdkfns&dfandfasdf
+		{desc: "NO_SCHEMA_ERROR",
 			args: args{actualurl: "lnurl.com.org"},
-			want: strings.ToUpper("LNURL1D3H82UNV9E3K7MFWDAEXWSE0TLM"), wantErr: false}, // lnurl.com.org,
-		{desc: "domain",
+			want: strings.ToUpper("LNURL1D3H82UNV9E3K7MFWDAEXWSE0TLM"), wantErr: false}, // https://lnurl.com.org,
+		{desc: "NO_SCHEMA_TLD_COM",
 			args: args{actualurl: "lnurl.com"},
-			want: "LNURL1D3H82UNV9E3K7MG347503", wantErr: false}, // lnurl.com
-		{desc: "lnurlp",
-			args: args{actualurl: "lnurlp://api.fiatjaf.com/v2/lnurl/pay"},
-			want: "LNURL1D3H82UNVWQAZ7TMPWP5JUENFV96X5CTX9E3K7MF0WCEZ7MRWW4EXCTMSV9US75V5UG"}, // lnurlp://api.fiatjaf.com/v2/lnurl/pay
-		{desc: "onion_lnurlp",
+			want: "LNURL1D3H82UNV9E3K7MG347503", wantErr: false}, // https://lnurl.com
+		{desc: "COM_ORG_NO_SCHEMA",
+			args: args{actualurl: "lnurl.com.org"},
+			want: strings.ToUpper("LNURL1D3H82UNV9E3K7MFWDAEXWSE0TLM"), wantErr: false}, // https://lnurl.com.org,
+		{desc: "LUD17_P_ONION_BECH",
 			args: args{actualurl: "lnurlp://api.fiatjaf.onion/v2/lnurl/pay"},
-			want: "LNURL1D3H82UNVWQAZ7TMPWP5JUENFV96X5CTX9EHKU6T0DCHHVV30D3H82UNV9ACXZ7GLKMARH"}, // lnurlp://api.fiatjaf.onion/v2/lnurl/pay
-		{desc: "https_onion",
-			args: args{actualurl: "https://api.fiatjaf.onion/v2/lnurl/pay"},
-			want: "LNURL1DP68GURN8GHJ7CTSDYHXV6TPW34XZE3WDAHXJMMW9AMRYTMVDE6HYMP0WPSHJMP4SG6"}, // https://api.fiatjaf.onion/v2/lnurl/pay
-		{desc: "http",
-			args: args{actualurl: "http://api.fiatjaf.com/v2/lnurl/pay"},
-			want: "LNURL1DP68GUP69UHKZURF9ENXJCT5DFSKVTNRDAKJ7A3J9AKXUATJDSHHQCTE6UJWJL"}, // http://api.fiatjaf.com/v2/lnurl/pay
-	}
+			want: "LNURL1D3H82UNVWQAZ7TMPWP5JUENFV96X5CTX9EHKU6T0DCHHVV30D3H82UNV9ACXZ7GLKMARH"}, // http://api.fiatjaf.onion/v2/lnurl/pay
+		{desc: "LUD17_A_ONION_BECH",
+			args: args{actualurl: "lnurla://api.fiatjaf.onion/v2/lnurl/pay"},
+			want: "LNURL1D3H82UNVVYAZ7TMPWP5JUENFV96X5CTX9EHKU6T0DCHHVV30D3H82UNV9ACXZ7GEDZQYL"}, // http://api.fiatjaf.onion/v2/lnurl/pay
+		{desc: "LUD17_W_ONION_BECH",
+			args: args{actualurl: "lnurlw://api.fiatjaf.onion/v2/lnurl/pay"},
+			want: "LNURL1D3H82UNVWUAZ7TMPWP5JUENFV96X5CTX9EHKU6T0DCHHVV30D3H82UNV9ACXZ7GRWJJDV"}, // lnurlp://api.fiatjaf.onion/v2/lnurl/pay
+		{desc: "LUD17_IP_AND_PORT_BECH",
+			args: args{actualurl: "lnurlp://1.1.1.1:8080/v1/lnurl/pay"},
+			want: "LNURL1D3H82UNVWQAZ7TE39CCJUVFWXYARSVPCXQHHVVF0D3H82UNV9ACXZ7G5A0M2Q"}, // https://1.1.1.1:8080/v1/lnurl/pay
+		{desc: "LUD17_IP_BECH",
+			args: args{actualurl: "lnurlp://1.1.1.1/v1/lnurl/pay"},
+			want: "LNURL1D3H82UNVWQAZ7TE39CCJUVFWXYHHVVF0D3H82UNV9ACXZ7GTCNKJU"}, // https://1.1.1.1/v1/lnurl/pay
+		{desc: "LUD1_ONION",
+			args: args{actualurl: "http://juhaavcaxhxlp77nkq76byazcldy2hlmovfu2epvl5ankdibsot4csyd.onion/"},
+			want: strings.ToUpper("lnurl1dp68gup69uhk5atgv9shvcmp0p58smrsxumku6m3xumxy7tp0f3kcerexf5xcmt0wen82vn9wpmxcdtpde4kg6tzwdhhgdrrwdukgtn0de5k7m30p4k848"), wantErr: false},
+		{desc: "HTTPS",
+			args: args{actualurl: "https://api.fiatjaf.com/v2/lnurl/pay"},
+			want: strings.ToUpper("lnurl1dp68gurn8ghj7ctsdyhxv6tpw34xze3wvdhk6tmkxghkcmn4wfkz7urp0y0q3peg")}}
 	for _, tt := range tests {
 		tt.name = tt.args.actualurl
-		t.Run(fmt.Sprintf("%s__%s", tt.name, tt.desc), func(t *testing.T) {
+		t.Run(fmt.Sprintf("%s", tt.desc), func(t *testing.T) {
 			got, err := LNURLEncode(tt.args.actualurl)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("LNURLDecodeStrict() error = %v, wantErr %v", err, tt.wantErr)
@@ -239,48 +258,58 @@ func TestLNURLDecode(t *testing.T) {
 		args    args
 		want    string
 		wantErr bool
-	}{
-		{desc: "onion",
-			args: args{code: "onion://lnurl.fiatjaf.onion"}, // change scheme
-			want: "", wantErr: true},
-		{desc: "change_scheme",
-			args: args{code: "lnurl1d3h82unvwqaz7tmpwp5juenfv96x5ctx9e3k7mf0wccj7mrww4exctmsv9usxr8j98"}, // lnurlp://api.fiatjaf.com/v1/lnurl/pay
-			want: "lnurlp://api.fiatjaf.com/v1/lnurl/pay"},
-		{desc: "puny",
-			args: args{code: "lnurl1dp68gurn8ghj77rw95khx7r3wc6kwv3nv3uhyvmpxserscfwvdhk6tmkxyhkcmn4wfkz7urp0y6jmn9j"}, // https://xn--sxqv5g23dyr3a428a.com/v1/lnurl/pay
-			want: "https://xn--sxqv5g23dyr3a428a.com/v1/lnurl/pay"},                                                    // check puny code
-		{desc: "puny2",
-			args: args{code: "lnurl1dp68gurn8ghjle443052l909sxr7t8ulukgg6tnrdakj7a339akxuatjdshhqctea4v3jm"},
-			want: "https://测试假域名.com/v1/lnurl/pay"}, // check puny code
-		{desc: "puny_onion",
-			args: args{code: "lnurl1dp68gup69uh7ddvtazhetevpsljel8l9jzxjummwd9hkutmkxyhkcmn4wfkz7urp0ygc52rr"}, // http://测试假域名.onion/v1/lnurl/pay
-			want: "http://测试假域名.onion/v1/lnurl/pay"},                                                           // check puny onion (not sure know if this is possible)
-		{desc: "domain_onion",
-			args: args{code: "lnurl1dp68gurn8ghj7er0d4skjm3wdahxjmmw9amrztmvde6hymp0wpshjcw5kvw"}, // https://domain.onion/v1/lnurl/pay
-			want: "https://domain.onion/v1/lnurl/pay"},                                            // check puny onion (not sure know if this is possible)
-		{desc: "string",
-			args: args{code: "lnurl1d3h82unvjhypn2"},
-			want: "lnurl", wantErr: false}, // invalid domain name. returns error and decoded input
-		{desc: "string_uppercase",
-			args: args{code: strings.ToUpper("lnurl1d3h82unvjhypn2")},
-			want: "lnurl", wantErr: false},
-		{desc: "httpsScheme",
-			args: args{code: "https://lnurl.fiatjaf.com"}, // do noting
-			want: "https://lnurl.fiatjaf.com"},
-		{desc: "lnurlp",
+	}{{desc: "INVALID_IP_NO_ERROR",
+		args: args{code: "lnurl1dahxjmmw8ghj7vf3xyhryt3e8yujuv368quq39nwhr"},
+		want: "onion://111.2.999.2:88", wantErr: false},
+		{desc: "LUD17_CHANGE_SCHEMA",
 			args: args{code: "lnurlp://lnurl.fiatjaf.com"}, // change scheme
 			want: "https://lnurl.fiatjaf.com"},
-
-		{desc: "encoded_onion",
-			args: args{code: "lnurl1dahxjmmw8ghj7mrww4exctnxd9shg6npvchx7mnfdahquxueex"}, // onion://lnurl.fiatjaf.onion change scheme
-			want: "onion://lnurl.fiatjaf.onion"},
-		{desc: "encoded_https_onion",
-			args: args{code: "lnurl1dp68gurn8ghj7mrww4exctnxd9shg6npvchx7mnfdahq874q6e"}, // https://lnurl.fiatjaf.onion change scheme
-			want: "https://lnurl.fiatjaf.onion"},
+		{desc: "ONION_SCHEMA_CHANGE_SCHEMA_ERROR",
+			args: args{code: "onion://lnurl.fiatjaf.onion"}, // change scheme
+			want: "", wantErr: true},
+		{desc: "LUD17_BECH32_ENCODED_CHANGE_SCHEMA_ERROR",
+			args: args{code: "lnurl1d3h82unvwqaz7tmpwp5juenfv96x5ctx9e3k7mf0wccj7mrww4exctmsv9usxr8j98"}, // lnurlp://api.fiatjaf.com/v1/lnurl/pay
+			want: "lnurlp://api.fiatjaf.com/v1/lnurl/pay", wantErr: false},
+		{desc: "LUD17_BECH32_ENCODED_CHANGE_SCHEMA_IP_ERROR",
+			args: args{code: "lnurl1dp68gup69uhnzt339ccjuvf0wccj7mrww4exctmsv9usux0rql"}, // lnurlp://api.fiatjaf.com/v1/lnurl/pay
+			want: "http://1.1.1.1/v1/lnurl/pay", wantErr: false},
+		{desc: "LUD1_ENCODED_CHANGE_SCHEMA",
+			args: args{code: "lnurl1dp68gurn8ghj7vfwxyhrzt339amrztmvde6hymp0wpshjr50pch"}, // https://1.1.1.1/v1/lnurl/pay
+			want: "https://1.1.1.1/v1/lnurl/pay"},
+		{desc: "LUD1_PUNY_SAME_SCHEMA",
+			args: args{code: "lnurl1dp68gurn8ghj77rw95khx7r3wc6kwv3nv3uhyvmpxserscfwvdhk6tmkxyhkcmn4wfkz7urp0y6jmn9j"}, // https://xn--sxqv5g23dyr3a428a.com/v1/lnurl/pay
+			want: "https://xn--sxqv5g23dyr3a428a.com/v1/lnurl/pay"},                                                    // check puny code
+		{desc: "LUD1_IDN_SAME_SCHEMA",
+			args: args{code: "lnurl1dp68gurn8ghjle443052l909sxr7t8ulukgg6tnrdakj7a339akxuatjdshhqctea4v3jm"},
+			want: "https://测试假域名.com/v1/lnurl/pay"}, // check puny code
+		{desc: "LUD17_BECH32_IDN_CHANGE_SCHEMA_ERROR",
+			args: args{code: "lnurl1d3h82unvwuaz7tlxkk973tu4ukqc0evlnljeprfwvdhk6tmkxyhkcmn4wfkz7urp0y93ltxj"},
+			want: "lnurlw://测试假域名.com/v1/lnurl/pay", wantErr: false}, // check puny code
+		{desc: "LUD1_BECH32_ONION_SAME_SCHEMA",
+			args: args{code: "lnurl1dp68gup69uh7ddvtazhetevpsljel8l9jzxjummwd9hkutmkxyhkcmn4wfkz7urp0ygc52rr"}, // http://测试假域名.onion/v1/lnurl/pay
+			want: "http://测试假域名.onion/v1/lnurl/pay"},                                                           // check puny onion (not sure know if this is possible)
+		{desc: "LUD1_BECH32_ONION_CHANGE_SCHEMA_ERROR",
+			args: args{code: "lnurl1dp68gurn8ghj7er0d4skjm3wdahxjmmw9amrztmvde6hymp0wpshjcw5kvw"},
+			want: "https://domain.onion/v1/lnurl/pay", wantErr: false}, // check puny onion (not sure know if this is possible)
+		{desc: "RANDOM_STRING_ERROR",
+			args: args{code: "lnurl1d3h82unvjhypn2"},
+			want: "lnurl", wantErr: false}, // invalid domain name. returns error and decoded input
+		{desc: "RANDOM_STRING_UPPERCASE_ERROR",
+			args: args{code: strings.ToUpper("lnurl1d3h82unvjhypn2")},
+			want: "lnurl", wantErr: false},
+		{desc: "HTTPS",
+			args: args{code: "https://lnurl.fiatjaf.com"}, // do noting
+			want: "https://lnurl.fiatjaf.com"},
+		{desc: "ONION_SCHEMA_CHANGE_SCHEMA_ERROR",
+			args: args{code: "lnurl1dahxjmmw8ghj7mrww4exctnxd9shg6npvchx7mnfdahquxueex"}, // change scheme
+			want: "onion://lnurl.fiatjaf.onion", wantErr: false},
+		{desc: "ONION_HTTPS_CHANGE_SCHEMA_ERROR",
+			args: args{code: "lnurl1dp68gurn8ghj7mrww4exctnxd9shg6npvchx7mnfdahq874q6e"}, // change scheme
+			want: "https://lnurl.fiatjaf.onion", wantErr: false},
 	}
 	for _, tt := range tests {
 		tt.name = tt.args.code
-		t.Run(fmt.Sprintf("%s__%s", tt.name, tt.desc), func(t *testing.T) {
+		t.Run(fmt.Sprintf("%s", tt.desc), func(t *testing.T) {
 			got, err := LNURLDecode(tt.args.code)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("LNURLDecode() error = %v, wantErr %v", err, tt.wantErr)
@@ -320,7 +349,7 @@ func TestLNURLEncodeDecode(t *testing.T) {
 			args: args{input: "lnurl"}, want: "lnurl", wantErr: true},
 	}
 	for _, tt := range tests {
-		t.Run(fmt.Sprintf("%s__%s", tt.name, tt.desc), func(t *testing.T) {
+		t.Run(fmt.Sprintf("%s", tt.desc), func(t *testing.T) {
 			// encode string first
 			enc, err := LNURLEncodeStrict(tt.args.input)
 			if err != nil {
@@ -359,6 +388,108 @@ func TestLNURLEncodeDecode(t *testing.T) {
 					t.Errorf("LNURLDecodeStrict() error = %v, wantErr %v", err, tt.wantErr)
 				}
 				return
+			}
+			// check if decoded string == actualurl
+			if dec != tt.want {
+				t.Errorf("LNURLDecodeStrict() enc = %v, dec %v", enc, dec)
+			}
+		})
+	}
+}
+
+// TestLNURLEncodeDecode will test if encoding strict and decoding default returns the expected string
+func TestLNURLEncodeStrictDecode(t *testing.T) {
+	type args struct {
+		input string
+	}
+	tests := []struct {
+		desc    string
+		name    string
+		args    args
+		wantErr bool
+		want    string
+	}{
+		{desc: "ONION_ADD_SCHEME",
+			args: args{input: "hellosir.onion"}, wantErr: true, want: "http://hellosir.onion"}, // will be encoded to http://
+		{desc: "HTTPS",
+			args: args{input: "https://api.fiatjaf.com/v1/lnurl/pay"}, want: "https://api.fiatjaf.com/v1/lnurl/pay"},
+		{desc: "ONION_SCHEME",
+			args: args{input: "onion://lnurl.fiatjaf.com"}, want: "https://lnurl.fiatjaf.com", wantErr: true},
+		{desc: "lnurlp",
+			args: args{input: "lnurlp://lnurl.fiatjaf.com"}, want: "https://lnurl.fiatjaf.com", wantErr: false}, // will be encoded to https://
+		{desc: "NO_SCHEME",
+			args: args{input: "lnurl.fiatjaf.com"}, want: "https://lnurl.fiatjaf.com", wantErr: true},
+	}
+	for _, tt := range tests {
+		t.Run(fmt.Sprintf("%s", tt.desc), func(t *testing.T) {
+			// encode string first
+			enc, err := LNURLEncodeStrict(tt.args.input)
+			if err != nil {
+				if !tt.wantErr {
+					t.Errorf("LNURLDecodeStrict() error = %v, wantErr %v", err, tt.wantErr)
+					return
+
+				}
+			}
+			// decode string
+			dec, err := LNURLDecode(enc)
+			if err != nil {
+				if !tt.wantErr {
+					t.Errorf("LNURLDecodeStrict() error = %v, wantErr %v", err, tt.wantErr)
+					return
+				}
+
+			}
+			// check if decoded string == actualurl
+			if dec != tt.want {
+				t.Errorf("LNURLDecodeStrict() enc = %v, dec %v", enc, dec)
+			}
+		})
+	}
+}
+
+// TestLNURLEncodeDecodeStrict will test if encoding default and decoding strict returns the expected string
+func TestLNURLEncodeDecodeStrict(t *testing.T) {
+	type args struct {
+		input string
+	}
+	tests := []struct {
+		desc    string
+		name    string
+		args    args
+		wantErr bool
+		want    string
+	}{
+		{desc: "ONION_ADD_SCHEME",
+			args: args{input: "hellosir.onion"}, wantErr: true, want: "http://hellosir.onion"}, // will be encoded to http://
+		{desc: "HTTPS",
+			args: args{input: "https://api.fiatjaf.com/v1/lnurl/pay"}, want: "https://api.fiatjaf.com/v1/lnurl/pay"},
+		{desc: "ONION_SCHEME",
+			args: args{input: "onion://lnurl.fiatjaf.com"}, want: "https://lnurl.fiatjaf.com", wantErr: true},
+		{desc: "lnurlp",
+			args: args{input: "lnurlp://lnurl.fiatjaf.com"}, want: "https://lnurl.fiatjaf.com", wantErr: true}, // will be encoded to https://
+		{desc: "NO_SCHEME",
+			args: args{input: "lnurl.fiatjaf.com"}, want: "https://lnurl.fiatjaf.com", wantErr: true},
+	}
+	for _, tt := range tests {
+		t.Run(fmt.Sprintf("%s", tt.desc), func(t *testing.T) {
+			// encode string first
+			enc, err := LNURLEncode(tt.args.input)
+			if err != nil {
+				if !tt.wantErr {
+					t.Errorf("LNURLDecodeStrict() error = %v, wantErr %v", err, tt.wantErr)
+					return
+
+				}
+			}
+			// decode string
+			dec, err := LNURLDecodeStrict(enc)
+			if err != nil {
+				if !tt.wantErr {
+					t.Errorf("LNURLDecodeStrict() error = %v, wantErr %v", err, tt.wantErr)
+					return
+				}
+
 			}
 			// check if decoded string == actualurl
 			if dec != tt.want {

--- a/codec_test.go
+++ b/codec_test.go
@@ -1,12 +1,15 @@
 package lnurl
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 )
 
-// TestLNURLDecode will test if LNURLDecode returns the expected string
-func TestLNURLDecode(t *testing.T) {
+// Starting tests with validation
+
+// TestLNURLDecodeStrict will test if LNURLDecodeStrict returns the expected string
+func TestLNURLDecodeStrict(t *testing.T) {
 	type args struct {
 		code string
 	}
@@ -27,8 +30,8 @@ func TestLNURLDecode(t *testing.T) {
 			args: args{code: "lnurl1dp68gurn8ghjle443052l909sxr7t8ulukgg6tnrdakj7a339akxuatjdshhqctea4v3jm"},
 			want: "https://测试假域名.com/v1/lnurl/pay"}, // check puny code
 		{desc: "puny_onion",
-			args: args{code: "lnurl1dp68gup69uh7ddvtazhetevpsljel8l9jzxjummwd9hkutmkxyhkcmn4wfkz7urp0ygc52rr"},
-			want: "http://测试假域名.onion/v1/lnurl/pay"}, // check puny onion (not sure know if this is possible)
+			args: args{code: "lnurl1dp68gup69uh7ddvtazhetevpsljel8l9jzxjummwd9hkutmkxyhkcmn4wfkz7urp0ygc52rr"}, // http://测试假域名.onion/v1/lnurl/pay
+			want: "http://测试假域名.onion/v1/lnurl/pay"},                                                           // check puny onion (not sure know if this is possible)
 		{desc: "puny_onion",
 			args: args{code: "lnurl1dp68gurn8ghj7er0d4skjm3wdahxjmmw9amrztmvde6hymp0wpshjcw5kvw"},
 			want: "http://domain.onion/v1/lnurl/pay"}, // check puny onion (not sure know if this is possible)
@@ -56,20 +59,21 @@ func TestLNURLDecode(t *testing.T) {
 	}
 	for _, tt := range tests {
 		tt.name = tt.args.code
-		t.Run(tt.name, func(t *testing.T) {
-			got, err := LNURLDecode(tt.args.code)
+		t.Run(fmt.Sprintf("%s__%s", tt.name, tt.desc), func(t *testing.T) {
+			got, err := LNURLDecodeStrict(tt.args.code)
 			if (err != nil) != tt.wantErr {
-				t.Errorf("LNURLDecode() error = %v, wantErr %v", err, tt.wantErr)
+				t.Errorf("LNURLDecodeStrict() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
 			if got != tt.want {
-				t.Errorf("LNURLDecode() got = %v, want %v", got, tt.want)
+				t.Errorf("LNURLDecodeStrict() got = %v, want %v", got, tt.want)
 			}
 		})
 	}
 }
 
-func TestLNURLEncodeWithValidation(t *testing.T) {
+// TestLNURLEncodeStrict will test if LNURLEncodeStrict returns the expected string
+func TestLNURLEncodeStrict(t *testing.T) {
 	type args struct {
 		actualurl string
 	}
@@ -80,64 +84,36 @@ func TestLNURLEncodeWithValidation(t *testing.T) {
 		want    string
 		wantErr bool
 	}{
-		{desc: "com.org_invalid",
+		{desc: "invalid_tld_want_error",
 			args: args{actualurl: "lnurl.com.orgs"},                                      //invalid tld
 			want: strings.ToUpper("LNURL1D3H82UNV9E3K7MFWDAEXWUCYVANJJ"), wantErr: true}, // lnurl.com.orgs
-		{desc: "onion",
-			args: args{actualurl: "http://juhaavcaxhxlp77nkq76byazcldy2hlmovfu2epvl5ankdibsot4csyd.onion/"},                                                                        //invalid tld
-			want: strings.ToUpper("lnurl1dp68gup69uhk5atgv9shvcmp0p58smrsxumku6m3xumxy7tp0f3kcerexf5xcmt0wen82vn9wpmxcdtpde4kg6tzwdhhgdrrwdukgtn0de5k7m30p4k848"), wantErr: false}, // lnurl.com.orgs
-		{desc: "invalid",
-			args: args{actualurl: "lnurl.msfmsdkfns&dfandfasdf"},                                              // invalid TLD
-			want: strings.ToUpper("LNURL1D3H82UNV9EKHXENDWDJXKENWWVNXGENPDEJXVCTNV3NQXM32ED"), wantErr: true}, // lnurl.msfmsdkfns&dfandfasdf
-		{desc: "com.org",
-			args: args{actualurl: "lnurl.com.org"},
-			want: strings.ToUpper("LNURL1DP68GURN8GHJ7MRWW4EXCTNRDAKJUMMJVUK5QJ46"), wantErr: false}, // https://lnurl.com.org,
 		{desc: "invalid_domain_name",
 			args: args{actualurl: "lnurl"},
 			want: strings.ToUpper("lnurl1d3h82unvjhypn2"), wantErr: true},
+		{desc: "invalid",
+			args: args{actualurl: "lnurl.msfmsdkfns&dfandfasdf"},                                              // invalid TLD
+			want: strings.ToUpper("LNURL1D3H82UNV9EKHXENDWDJXKENWWVNXGENPDEJXVCTNV3NQXM32ED"), wantErr: true}, // lnurl.msfmsdkfns&dfandfasdf
 		{desc: "invalid_domain_name",
 			args: args{actualurl: "lnur%%%l"},
 			want: strings.ToUpper("lnurl1d3h82u39y5jkc45g4zl"), wantErr: true},
-		{desc: "com",
-			args: args{actualurl: "lnurl.com"},
-			want: "LNURL1DP68GURN8GHJ7MRWW4EXCTNRDAKS6NPC70", wantErr: false}, // https://lnurl.com
-	}
-	for _, tt := range tests {
-		tt.name = tt.args.actualurl
-		t.Run(tt.name, func(t *testing.T) {
-			got, err := LNURLEncodeWithValidation(tt.args.actualurl)
-			if (err != nil) != tt.wantErr {
-				t.Errorf("LNURLDecode() error = %v, wantErr %v", err, tt.wantErr)
-				return
-			}
-			if got != tt.want {
-				t.Errorf("LNURLDecode() got = %v, want %v", got, tt.want)
-			}
-		})
-	}
-}
-
-// TestLNURLDecode will test if LNURLDecode returns the expected string
-func TestLNURLEncode(t *testing.T) {
-	type args struct {
-		actualurl string
-	}
-	tests := []struct {
-		name    string
-		desc    string
-		args    args
-		want    string
-		wantErr bool
-	}{
+		{desc: "invalid_domain_name",
+			args: args{actualurl: "lnurl"},
+			want: strings.ToUpper("lnurl1d3h82unvjhypn2"), wantErr: true}, // no domain validation
+		{desc: "invalid_domain_name",
+			args: args{actualurl: "lnur%%%l"},
+			want: strings.ToUpper("lnurl1d3h82u39y5jkc45g4zl"), wantErr: true}, // no domain validation
+		{desc: "onion",
+			args: args{actualurl: "http://juhaavcaxhxlp77nkq76byazcldy2hlmovfu2epvl5ankdibsot4csyd.onion/"},
+			want: strings.ToUpper("lnurl1dp68gup69uhk5atgv9shvcmp0p58smrsxumku6m3xumxy7tp0f3kcerexf5xcmt0wen82vn9wpmxcdtpde4kg6tzwdhhgdrrwdukgtn0de5k7m30p4k848"), wantErr: false},
 		{desc: "com.org",
 			args: args{actualurl: "lnurl.com.org"},
 			want: strings.ToUpper("LNURL1DP68GURN8GHJ7MRWW4EXCTNRDAKJUMMJVUK5QJ46"), wantErr: false}, // https://lnurl.com.org,
-		{desc: "invalid_domain_name",
-			args: args{actualurl: "lnurl"},
-			want: strings.ToUpper("lnurl1d3h82unvjhypn2"), wantErr: false}, // no domain validation
-		{desc: "invalid_domain_name",
-			args: args{actualurl: "lnur%%%l"},
-			want: strings.ToUpper("lnurl1d3h82u39y5jkc45g4zl"), wantErr: false}, // no domain validation
+		{desc: "com",
+			args: args{actualurl: "lnurl.com"},
+			want: "LNURL1DP68GURN8GHJ7MRWW4EXCTNRDAKS6NPC70", wantErr: false}, // https://lnurl.com
+		{desc: "com.org",
+			args: args{actualurl: "lnurl.com.org"},
+			want: strings.ToUpper("LNURL1DP68GURN8GHJ7MRWW4EXCTNRDAKJUMMJVUK5QJ46"), wantErr: false}, // https://lnurl.com.org,
 		{desc: "com",
 			args: args{actualurl: "lnurl.com"},
 			want: "LNURL1DP68GURN8GHJ7MRWW4EXCTNRDAKS6NPC70", wantErr: false}, // https://lnurl.com
@@ -156,8 +132,142 @@ func TestLNURLEncode(t *testing.T) {
 	}
 	for _, tt := range tests {
 		tt.name = tt.args.actualurl
-		t.Run(tt.name, func(t *testing.T) {
+		t.Run(fmt.Sprintf("%s__%s", tt.name, tt.desc), func(t *testing.T) {
+			got, err := LNURLEncodeStrict(tt.args.actualurl)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("LNURLDecodeStrict() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("LNURLDecodeStrict() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+// Start test without validation
+
+// TestLNURLDecodeStrict will test if LNURLDecodeStrict returns the expected string
+func TestLNURLEncode(t *testing.T) {
+	type args struct {
+		actualurl string
+	}
+	tests := []struct {
+		name    string
+		desc    string
+		args    args
+		want    string
+		wantErr bool
+	}{
+		{desc: "invalid_tld_want_error",
+			args: args{actualurl: "lnurl.com.orgs"},                                       //invalid tld
+			want: strings.ToUpper("LNURL1D3H82UNV9E3K7MFWDAEXWUCYVANJJ"), wantErr: false}, // lnurl.com.orgs
+		{desc: "invalid_domain_name",
+			args: args{actualurl: "lnurl"},
+			want: strings.ToUpper("lnurl1d3h82unvjhypn2"), wantErr: false},
+		{desc: "invalid",
+			args: args{actualurl: "lnurl.msfmsdkfns&dfandfasdf"},                                               // invalid TLD
+			want: strings.ToUpper("LNURL1D3H82UNV9EKHXENDWDJXKENWWVNXGENPDEJXVCTNV3NQXM32ED"), wantErr: false}, // lnurl.msfmsdkfns&dfandfasdf
+		{desc: "invalid_domain_name",
+			args: args{actualurl: "lnur%%%l"},
+			want: strings.ToUpper("lnurl1d3h82u39y5jkc45g4zl"), wantErr: false},
+		{desc: "invalid_domain_name",
+			args: args{actualurl: "lnurl"},
+			want: strings.ToUpper("lnurl1d3h82unvjhypn2"), wantErr: false}, // no domain validation
+		{desc: "invalid_domain_name",
+			args: args{actualurl: "lnur%%%l"},
+			want: strings.ToUpper("lnurl1d3h82u39y5jkc45g4zl"), wantErr: false}, // no domain validation
+		{desc: "onion",
+			args: args{actualurl: "http://juhaavcaxhxlp77nkq76byazcldy2hlmovfu2epvl5ankdibsot4csyd.onion/"},
+			want: strings.ToUpper("lnurl1dp68gup69uhk5atgv9shvcmp0p58smrsxumku6m3xumxy7tp0f3kcerexf5xcmt0wen82vn9wpmxcdtpde4kg6tzwdhhgdrrwdukgtn0de5k7m30p4k848"), wantErr: false}, // http://juhaavcaxhxlp77nkq76byazcldy2hlmovfu2epvl5ankdibsot4csyd.onion/
+		{desc: "domain",
+			args: args{actualurl: "lnurl.com.org"},
+			want: strings.ToUpper("LNURL1D3H82UNV9E3K7MFWDAEXWSE0TLM"), wantErr: false}, // lnurl.com.org,
+		{desc: "domain",
+			args: args{actualurl: "lnurl.com"},
+			want: "LNURL1D3H82UNV9E3K7MG347503", wantErr: false}, // lnurl.com
+		{desc: "lnurlp",
+			args: args{actualurl: "lnurlp://api.fiatjaf.com/v2/lnurl/pay"},
+			want: "LNURL1D3H82UNVWQAZ7TMPWP5JUENFV96X5CTX9E3K7MF0WCEZ7MRWW4EXCTMSV9US75V5UG"}, // lnurlp://api.fiatjaf.com/v2/lnurl/pay
+		{desc: "onion_lnurlp",
+			args: args{actualurl: "lnurlp://api.fiatjaf.onion/v2/lnurl/pay"},
+			want: "LNURL1D3H82UNVWQAZ7TMPWP5JUENFV96X5CTX9EHKU6T0DCHHVV30D3H82UNV9ACXZ7GLKMARH"}, // lnurlp://api.fiatjaf.onion/v2/lnurl/pay
+		{desc: "https_onion",
+			args: args{actualurl: "https://api.fiatjaf.onion/v2/lnurl/pay"},
+			want: "LNURL1DP68GURN8GHJ7CTSDYHXV6TPW34XZE3WDAHXJMMW9AMRYTMVDE6HYMP0WPSHJMP4SG6"}, // https://api.fiatjaf.onion/v2/lnurl/pay
+		{desc: "http",
+			args: args{actualurl: "http://api.fiatjaf.com/v2/lnurl/pay"},
+			want: "LNURL1DP68GUP69UHKZURF9ENXJCT5DFSKVTNRDAKJ7A3J9AKXUATJDSHHQCTE6UJWJL"}, // http://api.fiatjaf.com/v2/lnurl/pay
+	}
+	for _, tt := range tests {
+		tt.name = tt.args.actualurl
+		t.Run(fmt.Sprintf("%s__%s", tt.name, tt.desc), func(t *testing.T) {
 			got, err := LNURLEncode(tt.args.actualurl)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("LNURLDecodeStrict() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("LNURLDecodeStrict() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestLNURLDecodeStrict will test if LNURLDecodeStrict returns the expected string
+func TestLNURLDecode(t *testing.T) {
+	type args struct {
+		code string
+	}
+	tests := []struct {
+		name    string
+		desc    string
+		args    args
+		want    string
+		wantErr bool
+	}{
+		{desc: "onion",
+			args: args{code: "onion://lnurl.fiatjaf.onion"}, // change scheme
+			want: "", wantErr: true},
+		{desc: "change_scheme",
+			args: args{code: "lnurl1d3h82unvwqaz7tmpwp5juenfv96x5ctx9e3k7mf0wccj7mrww4exctmsv9usxr8j98"}, // lnurlp://api.fiatjaf.com/v1/lnurl/pay
+			want: "lnurlp://api.fiatjaf.com/v1/lnurl/pay"},
+		{desc: "puny",
+			args: args{code: "lnurl1dp68gurn8ghj77rw95khx7r3wc6kwv3nv3uhyvmpxserscfwvdhk6tmkxyhkcmn4wfkz7urp0y6jmn9j"}, // https://xn--sxqv5g23dyr3a428a.com/v1/lnurl/pay
+			want: "https://xn--sxqv5g23dyr3a428a.com/v1/lnurl/pay"},                                                    // check puny code
+		{desc: "puny2",
+			args: args{code: "lnurl1dp68gurn8ghjle443052l909sxr7t8ulukgg6tnrdakj7a339akxuatjdshhqctea4v3jm"},
+			want: "https://测试假域名.com/v1/lnurl/pay"}, // check puny code
+		{desc: "puny_onion",
+			args: args{code: "lnurl1dp68gup69uh7ddvtazhetevpsljel8l9jzxjummwd9hkutmkxyhkcmn4wfkz7urp0ygc52rr"}, // http://测试假域名.onion/v1/lnurl/pay
+			want: "http://测试假域名.onion/v1/lnurl/pay"},                                                           // check puny onion (not sure know if this is possible)
+		{desc: "domain_onion",
+			args: args{code: "lnurl1dp68gurn8ghj7er0d4skjm3wdahxjmmw9amrztmvde6hymp0wpshjcw5kvw"}, // https://domain.onion/v1/lnurl/pay
+			want: "https://domain.onion/v1/lnurl/pay"},                                            // check puny onion (not sure know if this is possible)
+		{desc: "string",
+			args: args{code: "lnurl1d3h82unvjhypn2"},
+			want: "lnurl", wantErr: false}, // invalid domain name. returns error and decoded input
+		{desc: "string_uppercase",
+			args: args{code: strings.ToUpper("lnurl1d3h82unvjhypn2")},
+			want: "lnurl", wantErr: false},
+		{desc: "httpsScheme",
+			args: args{code: "https://lnurl.fiatjaf.com"}, // do noting
+			want: "https://lnurl.fiatjaf.com"},
+		{desc: "lnurlp",
+			args: args{code: "lnurlp://lnurl.fiatjaf.com"}, // change scheme
+			want: "https://lnurl.fiatjaf.com"},
+
+		{desc: "encoded_onion",
+			args: args{code: "lnurl1dahxjmmw8ghj7mrww4exctnxd9shg6npvchx7mnfdahquxueex"}, // onion://lnurl.fiatjaf.onion change scheme
+			want: "onion://lnurl.fiatjaf.onion"},
+		{desc: "encoded_https_onion",
+			args: args{code: "lnurl1dp68gurn8ghj7mrww4exctnxd9shg6npvchx7mnfdahq874q6e"}, // https://lnurl.fiatjaf.onion change scheme
+			want: "https://lnurl.fiatjaf.onion"},
+	}
+	for _, tt := range tests {
+		tt.name = tt.args.code
+		t.Run(fmt.Sprintf("%s__%s", tt.name, tt.desc), func(t *testing.T) {
+			got, err := LNURLDecode(tt.args.code)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("LNURLDecode() error = %v, wantErr %v", err, tt.wantErr)
 				return
@@ -169,7 +279,8 @@ func TestLNURLEncode(t *testing.T) {
 	}
 }
 
-// TestLNURLEncodeDecode will test if encoding and decoding a lnurl will result in the same string
+// TestLNURLEncodeDecode will test if encoding and decoding multiple times returns the expected string
+// this test will fail without validation
 func TestLNURLEncodeDecode(t *testing.T) {
 	type args struct {
 		input string
@@ -195,49 +306,49 @@ func TestLNURLEncodeDecode(t *testing.T) {
 			args: args{input: "lnurl"}, want: "lnurl", wantErr: true},
 	}
 	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
+		t.Run(fmt.Sprintf("%s__%s", tt.name, tt.desc), func(t *testing.T) {
 			// encode string first
-			enc, err := LNURLEncode(tt.args.input)
+			enc, err := LNURLEncodeStrict(tt.args.input)
 			if err != nil {
 				if !tt.wantErr {
-					t.Errorf("LNURLDecode() error = %v, wantErr %v", err, tt.wantErr)
+					t.Errorf("LNURLDecodeStrict() error = %v, wantErr %v", err, tt.wantErr)
 				}
 				return
 			}
 			// decode string
-			dec, err := LNURLDecode(enc)
+			dec, err := LNURLDecodeStrict(enc)
 			if err != nil {
 				if !tt.wantErr {
-					t.Errorf("LNURLDecode() error = %v, wantErr %v", err, tt.wantErr)
+					t.Errorf("LNURLDecodeStrict() error = %v, wantErr %v", err, tt.wantErr)
 				}
 				return
 			}
 			// decode string
-			dec, err = LNURLDecode(enc)
+			dec, err = LNURLDecodeStrict(enc)
 			if err != nil {
 				if !tt.wantErr {
-					t.Errorf("LNURLDecode() error = %v, wantErr %v", err, tt.wantErr)
+					t.Errorf("LNURLDecodeStrict() error = %v, wantErr %v", err, tt.wantErr)
 				}
 				return
 			}
-			enc, err = LNURLEncode(tt.args.input)
+			enc, err = LNURLEncodeStrict(tt.args.input)
 			if err != nil {
 				if !tt.wantErr {
-					t.Errorf("LNURLDecode() error = %v, wantErr %v", err, tt.wantErr)
+					t.Errorf("LNURLDecodeStrict() error = %v, wantErr %v", err, tt.wantErr)
 				}
 				return
 			}
 			// decode string
-			dec, err = LNURLDecode(enc)
+			dec, err = LNURLDecodeStrict(enc)
 			if err != nil {
 				if !tt.wantErr {
-					t.Errorf("LNURLDecode() error = %v, wantErr %v", err, tt.wantErr)
+					t.Errorf("LNURLDecodeStrict() error = %v, wantErr %v", err, tt.wantErr)
 				}
 				return
 			}
 			// check if decoded string == actualurl
 			if dec != tt.want {
-				t.Errorf("LNURLDecode() enc = %v, dec %v", enc, dec)
+				t.Errorf("LNURLDecodeStrict() enc = %v, dec %v", enc, dec)
 			}
 		})
 	}

--- a/codec_test.go
+++ b/codec_test.go
@@ -20,6 +20,12 @@ func TestLNURLDecodeStrict(t *testing.T) {
 		want    string
 		wantErr bool
 	}{
+		{desc: "ip_change_scheme",
+			args: args{code: "lnurl1dp68gup69uhnzt339ccjuvf0wccj7mrww4exctmsv9usux0rql"}, // lnurlp://api.fiatjaf.com/v1/lnurl/pay
+			want: "https://1.1.1.1/v1/lnurl/pay"},
+		{desc: "ip_keep_scheme",
+			args: args{code: "lnurl1dp68gurn8ghj7vfwxyhrzt339amrztmvde6hymp0wpshjr50pch"}, // https://1.1.1.1/v1/lnurl/pay
+			want: "https://1.1.1.1/v1/lnurl/pay"},
 		{desc: "change_scheme",
 			args: args{code: "lnurl1d3h82unvwqaz7tmpwp5juenfv96x5ctx9e3k7mf0wccj7mrww4exctmsv9usxr8j98"}, // lnurlp://api.fiatjaf.com/v1/lnurl/pay
 			want: "https://api.fiatjaf.com/v1/lnurl/pay"},
@@ -84,9 +90,21 @@ func TestLNURLEncodeStrict(t *testing.T) {
 		want    string
 		wantErr bool
 	}{
+		{desc: "punycode_change_scheme",
+			args: args{actualurl: "http://看.com"},
+			want: strings.ToUpper("lnurl1dp68gurn8ghjleuu3vhxxmmdrmldr8")}, // https://看.com
+		{desc: "punycode_keep_scheme",
+			args: args{actualurl: "http://看.com"},
+			want: strings.ToUpper("lnurl1dp68gurn8ghjleuu3vhxxmmdrmldr8")}, // https://看.com
+		{desc: "ip_and_port_change_scheme",
+			args: args{actualurl: "lnurlp://1.1.1.1:8080/v1/lnurl/pay"},
+			want: strings.ToUpper("lnurl1dp68gurn8ghj7vfwxyhrzt338gurqwps9amrztmvde6hymp0wpshjtl57q3")}, // https://1.1.1.1:8080/v1/lnurl/pay
+		{desc: "ip_change_scheme",
+			args: args{actualurl: "lnurlp://1.1.1.1/v1/lnurl/pay"},
+			want: strings.ToUpper("lnurl1dp68gurn8ghj7vfwxyhrzt339amrztmvde6hymp0wpshjr50pch")}, // https://1.1.1.1/v1/lnurl/pay
 		{desc: "invalid_tld_want_error",
-			args: args{actualurl: "lnurl.com.orgs"},                                      //invalid tld
-			want: strings.ToUpper("LNURL1D3H82UNV9E3K7MFWDAEXWUCYVANJJ"), wantErr: true}, // lnurl.com.orgs
+			args: args{actualurl: "lnurl.com.btc"},                                     //invalid tld
+			want: strings.ToUpper("LNURL1D3H82UNV9E3K7MFWVF6XXSVAUH5"), wantErr: true}, // lnurl.com.btc
 		{desc: "invalid_domain_name",
 			args: args{actualurl: "lnurl"},
 			want: strings.ToUpper("lnurl1d3h82unvjhypn2"), wantErr: true},

--- a/go.mod
+++ b/go.mod
@@ -6,4 +6,5 @@ require (
 	github.com/btcsuite/btcd/btcec/v2 v2.2.0
 	github.com/nbd-wtf/ln-decodepay v1.5.1
 	github.com/tidwall/gjson v1.6.1
+	golang.org/x/net v0.0.0-20211015210444-4f30a5c0130f
 )


### PR DESCRIPTION

Hello, 

this is a continuation of #10 

# Changes
* Added strict encoder for LUD-01 and LUD-17.
* Added strict decoder for LUD-01 and LUD-17.
* Added more tests (encode strict -> decode default / encode default -> decode strict).

Default encoders stay untouched to prevent breaking changes. People adopting LUD-17 should start using strict implementation. 

This could increase the compatibility during transition time. Even if people mix up both encodings 
and send `lnurlp://` scheme - bech32 encoded lnurls, strict users will be able to decode and resolve the lnurl. 

Strict function users should **NOT** check the error! -> we should probably return `bool ok` instead of `error err`  

Once the transition is finished, all encoders and decoders should be deprecated.

# Encoders 
* default encoders do only support LUD-01 lnurl -> will always encode to bech32 
* strict encoders support both LUD-01 and LUD-17 lnurl -> return url plain-text if any `lnurl://` protocol scheme is detected.

strict encoders will always fall back to **RESOLVABLE** LUD-01 urls. 
The missing protocol scheme will be added/updated to `https://` if that's necessary / possible. 

Any manipulation to the input string will return an error (or !ok) to the function caller. 
Invalid domain names, ips, and protocol schemes will also force an error. 
The strict function will still return the encoded string, even if any error occurs. 

## Example
### Default
| INPUT                                   | OUTPUT_PLAIN                            | ERROR | comment               |      OUTPUT          |
|-----------------------------------------|-----------------------------------------|-------|-----------------------|-----------------------|
| onion://111.2.999.2:88                  | onion://111.2.999.2:88                  | false | invalid protocol / ip | lnurl1dahxjmmw8ghj7vf3xyhryt3e8yujuv368quq39nwhr |
| lnurl.com.btc                           | lnurl.com.btc                           | false | invalid tld           | LNURL1DP68GURN8GHJ7MRWW4EXCTNRDAKJUCN5VVXPFXPM           |
| lnurlp://api.fiatjaf.onion/v2/lnurl/pay | lnurlp://api.fiatjaf.onion/v2/lnurl/pay | false | LUD-1 and LUD-17 mix  | LNURL1D3H82UNVWQAZ7TMPWP5JUENFV96X5CTX9EHKU6T0DCHHVV30D3H82UNV9ACXZ7GLKMARH  |
| http://看.com                            | http://看.com                            | false | http invalid scheme   |         LNURL1DP68GUP69UH708YT9E3K7MGL572TH              |
| https://api.fiatjaf.com/v2/lnurl/pay                         | https://api.fiatjaf.com/v2/lnurl/pay                           | false | https valid scheme    |         lnurl1dp68gurn8ghj7ctsdyhxv6tpw34xze3wvdhk6tmkxghkcmn4wfkz7urp0y0q3peg              |



### Strict
| INPUT | OUTPUT_PLAIN                            | ERROR | COMMENT               |  OUTPUT |
|-------|-----------------------------------------|-------|-----------------------|---|
|    onion://111.2.999.2:88   | onion://111.2.999.2:88                  | true  | invalid protocol / ip |  lnurl1dahxjmmw8ghj7vf3xyhryt3e8yujuv368quq39nwhr |
|   lnurl.com.btc    | https://lnurl.com.btc                   | true  | invalid tld           | LNURL1D3H82UNV9E3K7MFWVF6XXSVAUH5  |
|   lnurlp://api.fiatjaf.onion/v2/lnurl/pay    | lnurlp://api.fiatjaf.onion/v2/lnurl/pay | false | using LUD-17          |  lnurlp://api.fiatjaf.onion/v2/lnurl/pay |
|    http://看.com   | https://看.com                           | true  | http invalid scheme  |         LNURL1DP68GUP69UH708YT9E3K7MGL572TH              |
| https://api.fiatjaf.com/v2/lnurl/pay                         | https://api.fiatjaf.com/v2/lnurl/pay                           | false | https valid scheme    |         lnurl1dp68gurn8ghj7ctsdyhxv6tpw34xze3wvdhk6tmkxghkcmn4wfkz7urp0y0q3peg              |

If the encoder detects lud-17 lnurl, no bech32 encoding will be applied.

# Decoders
* default decoder converts LUD-17 lnurl to https, only if they are not bech32 encoded. 
* strict decoder converts LUD-17 lnurl to https, even if they are bech32 encoded. 

strict decoders will follow the same error rules as encoders.


## Example
### Default
| INPUT                                            | INPUT_PLAIN                          | ERROR | comment               |      OUTPUT          |
|--------------------------------------------------|--------------------------------------|-------|-----------------------|-----------------------|
| lnurl1dahxjmmw8ghj7vf3xyhryt3e8yujuv368quq39nwhr | onion://111.2.999.2:88               | false | invalid protocol / ip | onion://111.2.999.2:88 |
| lnurlp://lnurl.fiatjaf.com                       | lnurlp://lnurl.fiatjaf.com           | false | change scheme         |       https://lnurl.fiatjaf.com     |
| lnurl1dp68gurn8ghj7er0d4skjm3wdahxjmmw9amrztmvde6hymp0wpshjcw5kvw          | https://domain.onion/v1/lnurl/pay    | false | https onion           | https://domain.onion/v1/lnurl/pay  |
| lnurl1d3h82unvjhypn2                                     | lnurl                                | false | rnd string            |         lnurl1d3h82unvjhypn2              |
| lnurl1d3h82unvwqaz7tmpwp5juenfv96x5ctx9e3k7mf0wccj7mrww4exctmsv9usxr8j98             | lnurlp://api.fiatjaf.com/v1/lnurl/pay | false |   LUD-1 and LUD-17 mix  |         lnurlp://api.fiatjaf.com/v1/lnurl/pay              |



### Strict
| INPUT                                            | INPUT_PLAIN                          | ERROR | comment               | OUTPUT                               |
|--------------------------------------------------|--------------------------------------|-------|-----------------------|--------------------------------------|
| lnurl1dahxjmmw8ghj7vf3xyhryt3e8yujuv368quq39nwhr | onion://111.2.999.2:88               | true  | invalid protocol / ip | onion://111.2.999.2:88               |
| lnurlp://lnurl.fiatjaf.com                       | lnurlp://lnurl.fiatjaf.com           | false | change scheme         | https://lnurl.fiatjaf.com            |
| lnurl1dp68gurn8ghj7er0d4skjm3wdahxjmmw9amrztmvde6hymp0wpshjcw5kvw          | https://domain.onion/v1/lnurl/pay    | true  | https onion           | http://domain.onion/v1/lnurl/pay     |
| lnurl1d3h82unvjhypn2                                     | lnurl                                | true  | rnd string            | lnurl1d3h82unvjhypn2                 |
| lnurl1d3h82unvwqaz7tmpwp5juenfv96x5ctx9e3k7mf0wccj7mrww4exctmsv9usxr8j98             | lnurlp://api.fiatjaf.com/v1/lnurl/pay | true  |   LUD-1 and LUD-17 mix  | https://api.fiatjaf.com/v1/lnurl/pay |


cheers 
