### PR TITLE
fix LNURLDecodeStrict and setScheme doc name

### DIFF
--- a/codec.go
+++ b/codec.go
@@ -146,7 +146,7 @@ func domainPort(host string) (string, string) {
 	return host, ""
 }
 
-// LNURLDecode takes a string and returns a valid lnurl, if possible.
+// LNURLDecodeStrict takes a string and returns a valid lnurl, if possible.
 // code can be
 func LNURLDecodeStrict(code string) (string, error) {
 	code = strings.ToLower(code)
@@ -203,7 +203,7 @@ func LNURLDecodeStrict(code string) (string, error) {
 	}
 }
 
-// setHttpsScheme will parse string url to url.Url.
+// setScheme will parse string url to url.Url.
 // if no scheme was found,
 func setScheme(u *lnUrl) (updated bool) {
 	if u.tld == "onion" {


### PR DESCRIPTION
Nit PR. Private function `setScheme` doesn't matter but I find it nicer to have the public one fixed.