### PR TITLE
upgrade gjson to v1.9.3

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,6 @@ go 1.14
 require (
 	github.com/btcsuite/btcd/btcec/v2 v2.2.0
 	github.com/nbd-wtf/ln-decodepay v1.5.1
-	github.com/tidwall/gjson v1.6.1
+	github.com/tidwall/gjson v1.9.3
 	golang.org/x/net v0.0.0-20211015210444-4f30a5c0130f
 )


### PR DESCRIPTION
GJSON is a Go package that provides a fast and simple way to get values from a json document. GJSON before 1.9.3 allows a ReDoS (regular expression denial of service) attack via crafted JSON. Due to improper bounds checking, maliciously crafted JSON objects can cause an out-of-bounds panic. If parsing user input, this may be used as a denial of service vector.

References:
https://github.com/advisories/GHSA-c9gm-7rfj-8w5h
https://nvd.nist.gov/vuln/detail/CVE-2021-42248
